### PR TITLE
account operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kcp-dev/kcp/sdk v0.28.0
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5
-	github.com/openmfp/account-operator v0.170.23
 	github.com/openmfp/golang-commons v0.150.11
 	github.com/pkg/errors v0.9.1
 	github.com/platform-mesh/account-operator v0.1.20

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,6 @@ github.com/onsi/ginkgo/v2 v2.22.1 h1:QW7tbJAUDyVDVOM5dFa7qaybo+CRfR7bemlQUN6Z8aM
 github.com/onsi/ginkgo/v2 v2.22.1/go.mod h1:S6aTpoRsSq2cZOd+pssHAlKW/Q/jZt6cPrPlnj4a1xM=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
-github.com/openmfp/account-operator v0.170.23 h1:yJPWEL/rBVFaL03ywrI9C2NCinwpWPQcEQay2x+pqHQ=
-github.com/openmfp/account-operator v0.170.23/go.mod h1:0DaxMZGJpqojZ6hKLKiftgRbJRwHS0ayhiMPRhJZFG0=
 github.com/openmfp/golang-commons v0.150.11 h1:g9NbX75c5GTQkF7qHRDHU4a/En0LVW45nd5Gi1lOV7U=
 github.com/openmfp/golang-commons v0.150.11/go.mod h1:6CUKMI6gmVldZa6HohpOV/g/xC8oNnX87cLT21BabSA=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=


### PR DESCRIPTION
Cleanup PR to remove openmfp account operator leftovers from go.mod:

I need it to trigger the CI in main branch as well.