### PR TITLE
listener refactoring

### DIFF
--- a/common/auth/metadata_injector_test.go
+++ b/common/auth/metadata_injector_test.go
@@ -157,11 +157,6 @@ users:
 			require.True(t, exists, "host should be present")
 			assert.Equal(t, tt.expectedHost, host)
 
-			// Verify path
-			path, exists := metadataMap["path"]
-			require.True(t, exists, "path should be present")
-			assert.Equal(t, tt.clusterPath, path)
-
 			// Verify auth
 			auth, exists := metadataMap["auth"]
 			require.True(t, exists, "auth should be present")
@@ -198,7 +193,6 @@ func TestInjectClusterMetadata(t *testing.T) {
 		schemaJSON   []byte
 		config       MetadataInjectionConfig
 		expectedHost string
-		expectedPath string
 		expectError  bool
 	}{
 		{
@@ -217,10 +211,8 @@ func TestInjectClusterMetadata(t *testing.T) {
 			}`),
 			config: MetadataInjectionConfig{
 				Host: "https://test-cluster.example.com:6443",
-				Path: "test-cluster",
 			},
 			expectedHost: "https://test-cluster.example.com:6443",
-			expectedPath: "test-cluster",
 			expectError:  false,
 		},
 		{
@@ -234,11 +226,9 @@ func TestInjectClusterMetadata(t *testing.T) {
 			}`),
 			config: MetadataInjectionConfig{
 				Host:         "https://original.example.com:6443",
-				Path:         "virtual-workspace/test",
 				HostOverride: "https://override.example.com:6443/services/test",
 			},
 			expectedHost: "https://override.example.com:6443/services/test",
-			expectedPath: "virtual-workspace/test",
 			expectError:  false,
 		},
 		{
@@ -252,10 +242,8 @@ func TestInjectClusterMetadata(t *testing.T) {
 			}`),
 			config: MetadataInjectionConfig{
 				Host: "https://kcp.example.com:6443/services/apiexport/some/path",
-				Path: "test-workspace",
 			},
 			expectedHost: "https://kcp.example.com:6443", // Should be stripped
-			expectedPath: "test-workspace",
 			expectError:  false,
 		},
 		{
@@ -267,7 +255,6 @@ func TestInjectClusterMetadata(t *testing.T) {
 			}`),
 			config: MetadataInjectionConfig{
 				Host: "https://test.example.com:6443",
-				Path: "test",
 			},
 			expectError: true,
 		},
@@ -302,11 +289,6 @@ func TestInjectClusterMetadata(t *testing.T) {
 			host, exists := metadataMap["host"]
 			require.True(t, exists, "host should be present")
 			assert.Equal(t, tt.expectedHost, host)
-
-			// Verify path
-			path, exists := metadataMap["path"]
-			require.True(t, exists, "path should be present")
-			assert.Equal(t, tt.expectedPath, path)
 		})
 	}
 }

--- a/docs/clusteraccess.md
+++ b/docs/clusteraccess.md
@@ -88,7 +88,6 @@ Generated schema files contain:
 }
 ```
 
-Optional (deprecated) field: you may still see `"path": "my-target-cluster"` inside `x-cluster-metadata` in legacy files. The gateway ignores this value.
 
 ### 4. Gateway Usage
 
@@ -108,11 +107,6 @@ The gateway:
   - Serves GraphQL API at `/{cluster-name}/graphql`
 - **Does NOT require KUBECONFIG** - all connection info comes from schema files
 
-### Notes on `path` simplification
-
-- Historically the listener embedded `"path"` inside `x-cluster-metadata` and also used `spec.path` to control the output filename.
-- The gateway no longer uses the embedded `path` value; routing is derived from the schema file name and request path context.
-- You may keep `spec.path` to control filenames on disk. The embedded metadata `path` field is optional and considered deprecated.
 
 ## Troubleshooting
 

--- a/docs/listener.md
+++ b/docs/listener.md
@@ -53,11 +53,10 @@ Notes:
   - `{"type":"kubeconfig","kubeconfig":"<base64>"}`
   - `{"type":"clientCert","certData":"<base64>","keyData":"<base64>"}`
 - The `ca.data` field is optional but recommended; if omitted and `auth` contains a kubeconfig, the listener attempts to extract the CA from that kubeconfig automatically.
-- Deprecated/optional: `path`. Older listeners included `"path":"<logical-or-file-path>"`. The gateway ignores this value and derives routing from the schema file name and request context. Keep it only for backward compatibility.
 
 Why we keep it simple:
 - All information needed to connect is either intrinsic to the target cluster (host, CA) or already available via selected auth material. We avoid injecting duplicate or derivable data.
-- We do not replicate routing information (`path`) since it’s defined by where the file is stored and how the gateway is addressed.
+- We do not replicate routing information in metadata; routing is defined by where the file is stored and how the gateway is addressed.
 
 #### KCP Reconciler (`reconciler/kcp/`)
 - Watches APIBinding resources in KCP workspaces

--- a/gateway/manager/targetcluster/cluster.go
+++ b/gateway/manager/targetcluster/cluster.go
@@ -28,11 +28,7 @@ type FileData struct {
 
 // ClusterMetadata represents the cluster connection metadata stored in schema files
 type ClusterMetadata struct {
-	Host string `json:"host"`
-	// Deprecated: Path is ignored by the gateway. The effective cluster/path is derived
-	// from the schema file name and request context. The field may still be present in
-	// schema files for backward compatibility with older listeners.
-	Path string        `json:"path,omitempty"`
+	Host string        `json:"host"`
 	Auth *AuthMetadata `json:"auth,omitempty"`
 	CA   *CAMetadata   `json:"ca,omitempty"`
 }

--- a/listener/reconciler/clusteraccess/metadata_injector.go
+++ b/listener/reconciler/clusteraccess/metadata_injector.go
@@ -11,16 +11,9 @@ import (
 )
 
 func injectClusterMetadata(ctx context.Context, schemaJSON []byte, clusterAccess gatewayv1alpha1.ClusterAccess, k8sClient client.Client, log *logger.Logger) ([]byte, error) {
-	// Determine the path
-	path := clusterAccess.Spec.Path
-	if path == "" {
-		path = clusterAccess.GetName()
-	}
-
 	// Create metadata injection config
 	config := auth.MetadataInjectionConfig{
 		Host: clusterAccess.Spec.Host,
-		Path: path,
 		Auth: clusterAccess.Spec.Auth,
 		CA:   clusterAccess.Spec.CA,
 	}

--- a/listener/reconciler/kcp/apibinding_controller_test.go
+++ b/listener/reconciler/kcp/apibinding_controller_test.go
@@ -285,7 +285,6 @@ users:
 				assert.Contains(t, s, `"schema":"test"`)
 				assert.Contains(t, s, `"x-cluster-metadata"`)
 				assert.Contains(t, s, `"host":"https://test.example.com"`)
-				assert.Contains(t, s, `"path":"root:org:new-cluster"`)
 			},
 			wantResult: ctrl.Result{},
 			wantErr:    false,
@@ -434,7 +433,6 @@ users:
 				s := string(data)
 				assert.Contains(t, s, `"schema":"existing"`)
 				assert.Contains(t, s, `"x-cluster-metadata"`)
-				assert.Contains(t, s, `"path":"root:org:unchanged-cluster"`)
 			},
 			wantResult: ctrl.Result{},
 			wantErr:    false,
@@ -488,7 +486,6 @@ users:
 				s := string(data)
 				assert.Contains(t, s, `"schema":"new"`)
 				assert.Contains(t, s, `"x-cluster-metadata"`)
-				assert.Contains(t, s, `"path":"root:org:changed-cluster"`)
 			},
 			wantResult: ctrl.Result{},
 			wantErr:    false,


### PR DESCRIPTION
Cleaned up metadata injection and refactored listener logic, primarily removing the path property from injected metadata.

### Changes

- Removed path injection: The path property was removed from the x-cluster-metadata injection logic across the codebase
- Documentation updates: Clarified that path in x-cluster-metadata is deprecated/ignored by the gateway. Routing is now derived from the schema file name and request context, not the embedded path metadata.
- Tests cleanup: Removed tests specifically verifying path presence or precedence in metadata injection.