### PR TITLE
listener refactoring: maximize reuse without forcing between the different modes (#75)

### DIFF
--- a/listener/reconciler/clusteraccess/reconciler.go
+++ b/listener/reconciler/clusteraccess/reconciler.go
@@ -40,6 +40,14 @@ func NewClusterAccessReconciler(
 	schemaResolver apischema.Resolver,
 	log *logger.Logger,
 ) (reconciler.CustomReconciler, error) {
+	// Allow dependencies to be supplied via opts when not provided explicitly for reuse
+	if ioHandler == nil {
+		ioHandler = opts.IOHandler
+	}
+	if schemaResolver == nil {
+		schemaResolver = opts.SchemaResolver
+	}
+
 	// Validate required dependencies
 	if ioHandler == nil {
 		return nil, fmt.Errorf("ioHandler is required")

--- a/listener/reconciler/kcp/reconciler.go
+++ b/listener/reconciler/kcp/reconciler.go
@@ -37,15 +37,25 @@ func NewKCPReconciler(
 		return nil, err
 	}
 
-	// Create IO handler for schema files
-	ioHandler, err := workspacefile.NewIOHandler(appCfg.OpenApiDefinitionsPath)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to create IO handler")
-		return nil, err
+	// Create or reuse IO handler for schema files
+	var ioHandler *workspacefile.FileHandler
+	if opts.IOHandler != nil {
+		ioHandler = opts.IOHandler
+	} else {
+		ioHandler, err = workspacefile.NewIOHandler(appCfg.OpenApiDefinitionsPath)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to create IO handler")
+			return nil, err
+		}
 	}
 
-	// Create schema resolver
-	schemaResolver := apischema.NewResolver(log)
+	// Create or reuse schema resolver
+	var schemaResolver apischema.Resolver
+	if opts.SchemaResolver != nil {
+		schemaResolver = opts.SchemaResolver
+	} else {
+		schemaResolver = apischema.NewResolver(log)
+	}
 
 	// Create cluster path resolver
 	clusterPathResolver, err := NewClusterPathResolver(opts.Config, opts.Scheme)

--- a/listener/reconciler/types.go
+++ b/listener/reconciler/types.go
@@ -3,6 +3,9 @@ package reconciler
 import (
 	"context"
 
+	"github.com/platform-mesh/kubernetes-graphql-gateway/listener/pkg/apischema"
+	"github.com/platform-mesh/kubernetes-graphql-gateway/listener/pkg/workspacefile"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -23,4 +26,8 @@ type ReconcilerOpts struct {
 	client.Client
 	ManagerOpts            ctrl.Options
 	OpenAPIDefinitionsPath string
+	// Optional shared dependencies to maximize reuse across modes. If nil,
+	// each reconciler may construct its own defaults.
+	IOHandler      *workspacefile.FileHandler
+	SchemaResolver apischema.Resolver
 }


### PR DESCRIPTION
This change simplifies the Gateway and Listener codebase by centralizing dependency injection for IO and schema resolvers, and unifying client creation logic, thereby maximizing code reuse across Standard and KCP operational modes.

### Changes
- Consolidated client creation in TargetCluster, removing explicit KCP branching from the main connection logic.
- Moved IOHandler and SchemaResolver initialization to cmd/listener.go, reducing duplication.
- Updated ReconcilerOpts to inject shared dependencies, enabling consistent behavior across both Standard and KCP modes.