### PR TITLE
fix: list queries to return version & add pagination support

### DIFF
--- a/tests/standard_k8s/gateway_test.go
+++ b/tests/standard_k8s/gateway_test.go
@@ -21,9 +21,11 @@ func (s *IntegrationTestSuite) TestConfigMapCRUD() {
 				query {
 					core {
 						ConfigMaps {
-							metadata {
-								name
-								namespace
+							items {
+								metadata {
+									name
+									namespace
+								}
 							}
 						}
 					}
@@ -117,9 +119,11 @@ func (s *IntegrationTestSuite) TestConfigMapCRUD() {
 				query ListConfigMaps($namespace: String!, $labelselector: String!) {
 					core {
 						ConfigMaps(namespace: $namespace, labelselector: $labelselector) {
-							metadata {
-								name
-								labels
+							items {
+								metadata {
+									name
+									labels
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Plural list queries now return pagination-aware envelopes (with `resourceVersion`, `continue`, `remainingItemCount`, and `items`) instead of bare arrays. List fields also support pagination via `limit` and `continue`.

### Other Changes
- Feature: List Envelope: * Feature: Pagination Args: Added `limit` and `continue` arguments to plural list fields for server-side pagination.
 
### Change Log
- 🔥 (breaking) Feature: Plural queries return an object with `resourceVersion`, `continue`, `remainingItemCount`, and `items`, replacing the previous bare array of items.