### PR TITLE
fix mutation and query consistency implementation

### DIFF
--- a/gateway/resolver/resolver.go
+++ b/gateway/resolver/resolver.go
@@ -416,15 +416,17 @@ func (r *Service) CommonResolver() graphql.FieldResolveFn {
 func (r *Service) SanitizeGroupName(groupName string) string {
 	originalGroupName := groupName
 
-	groupName = invalidGroupCharRegex.ReplaceAllString(groupName, "_")
+	sanitizedGroupName := invalidGroupCharRegex.ReplaceAllString(groupName, "_")
 	// If the name doesn't start with a letter or underscore, prepend '_'
-	if groupName != "" && !validGroupStartRegex.MatchString(groupName) {
-		groupName = "_" + groupName
+	if sanitizedGroupName != "" && !validGroupStartRegex.MatchString(sanitizedGroupName) {
+		sanitizedGroupName = "_" + sanitizedGroupName
 	}
 
-	r.storeOriginalGroupName(groupName, originalGroupName)
+	if _, exists := r.groupNames[sanitizedGroupName]; !exists || r.groupNames[sanitizedGroupName] == sanitizedGroupName {
+		r.storeOriginalGroupName(sanitizedGroupName, originalGroupName)
+	}
 
-	return groupName
+	return sanitizedGroupName
 }
 
 func (r *Service) storeOriginalGroupName(groupName, originalName string) {

--- a/gateway/resolver/resolver_test.go
+++ b/gateway/resolver/resolver_test.go
@@ -726,6 +726,8 @@ func TestSanitizeGroupName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			r := &resolver.Service{}
+			r.SetGroupNames(make(map[string]string))
 			result := r.SanitizeGroupName(tt.input)
 			assert.Equal(t, tt.expected, result)
 			assert.Equal(t, tt.input, r.GetGroupName(result), "The original group name should be stored correctly")


### PR DESCRIPTION
Fix group name mapping issue during schema generation caused by repeated sanitization.

### Changes
- SanitizeGroupName is called multiple times during schema generation.
- On the first call, the function correctly mapped the original group name (e.g. core.platform-mesh.io) to its sanitized form (core_platform_mesh_io). On subsequent calls with an already sanitized name, the function overwrote the original mapping with a self-mapping.
- Updated the logic to prevent overwriting existing mappings, ensuring the original group name is preserved.