### PR TITLE
feat: add applyYaml mutation for raw YAML resource management

### DIFF
--- a/docs/custom_queries.md
+++ b/docs/custom_queries.md
@@ -24,3 +24,45 @@ Each entry in the list may include the following fields: `group`, `version`, `ki
   }
 }
 ```
+
+## applyYaml
+
+`applyYaml` applies a Kubernetes resource from raw YAML using "apply" semantics:
+- Creates the resource if it doesn't exist
+- Updates the resource if it already exists
+
+This is useful when you have YAML manifests and want to apply them directly without constructing type-specific GraphQL mutations.
+
+### Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `yaml` | String! | Yes | YAML representation of the Kubernetes resource |
+| `dryRun` | Boolean | No | If true, validates without persisting changes |
+
+### Example
+
+```graphql
+mutation {
+  applyYaml(yaml: """
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: default
+data:
+  key: value
+""")
+}
+```
+
+With dry run:
+
+```graphql
+mutation {
+  applyYaml(
+    yaml: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n  namespace: default"
+    dryRun: true
+  )
+}
+```

--- a/gateway/resolver/apply_yaml_test.go
+++ b/gateway/resolver/apply_yaml_test.go
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and platform-mesh contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package resolver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/platform-mesh/golang-commons/logger/testlogger"
+	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApplyYaml(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	log := testlogger.New().Logger
+
+	tests := []struct {
+		name           string
+		existingObjs   []client.Object
+		args           map[string]any
+		wantErr        bool
+		errContains    string
+		validateResult func(t *testing.T, result any, fakeClient client.Client)
+	}{
+		{
+			name:         "create new ConfigMap",
+			existingObjs: nil,
+			args: map[string]any{
+				"yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value`,
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result any, fakeClient client.Client) {
+				resultMap, ok := result.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "test-config", resultMap["metadata"].(map[string]any)["name"])
+
+				var cm corev1.ConfigMap
+				err := fakeClient.Get(context.Background(), client.ObjectKey{Name: "test-config", Namespace: "default"}, &cm)
+				require.NoError(t, err)
+				assert.Equal(t, "value", cm.Data["key"])
+			},
+		},
+		{
+			name: "update existing ConfigMap",
+			existingObjs: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "test-config",
+						Namespace:       "default",
+						ResourceVersion: "123",
+					},
+					Data: map[string]string{"key": "old-value"},
+				},
+			},
+			args: map[string]any{
+				"yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: new-value`,
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result any, fakeClient client.Client) {
+				resultMap, ok := result.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "test-config", resultMap["metadata"].(map[string]any)["name"])
+
+				var cm corev1.ConfigMap
+				err := fakeClient.Get(context.Background(), client.ObjectKey{Name: "test-config", Namespace: "default"}, &cm)
+				require.NoError(t, err)
+				assert.Equal(t, "new-value", cm.Data["key"])
+			},
+		},
+		{
+			name:         "invalid YAML syntax",
+			existingObjs: nil,
+			args: map[string]any{
+				"yaml": `invalid: yaml: content: [`,
+			},
+			wantErr:     true,
+			errContains: "invalid YAML",
+		},
+		{
+			name:         "missing kind field",
+			existingObjs: nil,
+			args: map[string]any{
+				"yaml": `apiVersion: v1
+metadata:
+  name: test-config`,
+			},
+			wantErr:     true,
+			errContains: "YAML must contain kind field",
+		},
+		{
+			name:         "missing yaml argument",
+			existingObjs: nil,
+			args:         map[string]any{},
+			wantErr:      true,
+			errContains:  "missing required argument",
+		},
+		{
+			name:         "dry run does not persist",
+			existingObjs: nil,
+			args: map[string]any{
+				"yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dry-run-config
+  namespace: default
+data:
+  key: value`,
+				"dryRun": true,
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result any, fakeClient client.Client) {
+				resultMap, ok := result.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "dry-run-config", resultMap["metadata"].(map[string]any)["name"])
+
+				var cm corev1.ConfigMap
+				err := fakeClient.Get(context.Background(), client.ObjectKey{Name: "dry-run-config", Namespace: "default"}, &cm)
+				require.Error(t, err)
+			},
+		},
+		{
+			name:         "cluster-scoped resource (Namespace)",
+			existingObjs: nil,
+			args: map[string]any{
+				"yaml": `apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace`,
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result any, fakeClient client.Client) {
+				resultMap, ok := result.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "test-namespace", resultMap["metadata"].(map[string]any)["name"])
+
+				var ns corev1.Namespace
+				err := fakeClient.Get(context.Background(), client.ObjectKey{Name: "test-namespace"}, &ns)
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.existingObjs...).
+				Build()
+
+			svc := resolver.New(log, fakeClient)
+
+			resolverFn := svc.ApplyYaml()
+
+			result, err := resolverFn(graphql.ResolveParams{
+				Context: context.Background(),
+				Args:    tt.args,
+			})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.validateResult != nil {
+				tt.validateResult(t, result, fakeClient)
+			}
+		})
+	}
+}

--- a/gateway/resolver/arguments.go
+++ b/gateway/resolver/arguments.go
@@ -23,6 +23,7 @@ const (
 	ResourceVersionArg = "resourceVersion"
 	LimitArg           = "limit"
 	ContinueArg        = "continue"
+	YamlArg            = "yaml"
 )
 
 // FieldConfigArgumentsBuilder helps construct GraphQL field config arguments
@@ -118,6 +119,15 @@ func (b *FieldConfigArgumentsBuilder) WithContinue() *FieldConfigArgumentsBuilde
 	b.arguments[ContinueArg] = &graphql.ArgumentConfig{
 		Type:        graphql.String,
 		Description: "Continue token from a previous list call to retrieve the next page",
+	}
+	return b
+}
+
+// WithYaml adds a YAML string argument for applying Kubernetes resources
+func (b *FieldConfigArgumentsBuilder) WithYaml() *FieldConfigArgumentsBuilder {
+	b.arguments[YamlArg] = &graphql.ArgumentConfig{
+		Type:        graphql.NewNonNull(graphql.String),
+		Description: "YAML representation of the Kubernetes resource to apply",
 	}
 	return b
 }

--- a/gateway/resolver/resolver.go
+++ b/gateway/resolver/resolver.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,6 +35,7 @@ const (
 	DELETE_ITEM      = "DeleteItem"
 	SUBSCRIBE_ITEM   = "SubscribeItem"
 	SUBSCRIBE_ITEMS  = "SubscribeItems"
+	APPLY_YAML       = "ApplyYaml"
 )
 
 var (
@@ -47,6 +49,7 @@ type Provider interface {
 	CommonResolver() graphql.FieldResolveFn
 	SanitizeGroupName(string) string
 	RelationResolver(fieldName string, gvk schema.GroupVersionKind) graphql.FieldResolveFn
+	ApplyYaml() graphql.FieldResolveFn
 }
 
 type CrudProvider interface {
@@ -404,6 +407,75 @@ func (r *Service) DeleteItem(gvk schema.GroupVersionKind, scope v1.ResourceScope
 		}
 
 		return true, nil
+	}
+}
+
+// ApplyYaml returns a resolver that applies a Kubernetes resource from YAML.
+// It uses Get-then-Update/Create semantics: checks if resource exists first,
+// then updates or creates accordingly.
+func (r *Service) ApplyYaml() graphql.FieldResolveFn {
+	return func(p graphql.ResolveParams) (any, error) {
+		ctx, span := otel.Tracer("").Start(p.Context, APPLY_YAML)
+		defer span.End()
+
+		yamlInput, err := getStringArg(p.Args, YamlArg, true)
+		if err != nil {
+			return nil, err
+		}
+
+		var objMap map[string]any
+		if err := yaml.Unmarshal([]byte(yamlInput), &objMap); err != nil {
+			return nil, fmt.Errorf("invalid YAML: %w", err)
+		}
+
+		obj := &unstructured.Unstructured{Object: objMap}
+
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		if gvk.Kind == "" {
+			return nil, errors.New("YAML must contain kind field")
+		}
+
+		log := r.log.With().
+			Str("operation", "applyYaml").
+			Str("group", gvk.Group).
+			Str("version", gvk.Version).
+			Str("kind", gvk.Kind).
+			Str("name", obj.GetName()).
+			Logger()
+
+		dryRun := []string{}
+		if dryRunBool, _ := getBoolArg(p.Args, DryRunArg, false); dryRunBool {
+			dryRun = []string{"All"}
+		}
+
+		existing := &unstructured.Unstructured{}
+		existing.SetGroupVersionKind(gvk)
+		key := client.ObjectKey{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+		}
+
+		getErr := r.runtimeClient.Get(ctx, key, existing)
+
+		if getErr == nil {
+			obj.SetResourceVersion(existing.GetResourceVersion())
+			if err := r.runtimeClient.Update(ctx, obj, &client.UpdateOptions{DryRun: dryRun}); err != nil {
+				log.Error().Err(err).Msg("Failed to update object")
+				return nil, err
+			}
+			return obj.Object, nil
+		}
+
+		if apierrors.IsNotFound(getErr) {
+			if err := r.runtimeClient.Create(ctx, obj, &client.CreateOptions{DryRun: dryRun}); err != nil {
+				log.Error().Err(err).Msg("Failed to create object")
+				return nil, err
+			}
+			return obj.Object, nil
+		}
+
+		log.Error().Err(getErr).Msg("Failed to get object")
+		return nil, getErr
 	}
 }
 

--- a/gateway/schema/recursion_test.go
+++ b/gateway/schema/recursion_test.go
@@ -383,4 +383,10 @@ func (m *mockResolverProvider) SanitizeGroupName(group string) string {
 	return group
 }
 
+func (m *mockResolverProvider) ApplyYaml() graphql.FieldResolveFn {
+	return func(p graphql.ResolveParams) (any, error) {
+		return map[string]any{}, nil
+	}
+}
+
 var _ resolver.Provider = (*mockResolverProvider)(nil)

--- a/gateway/schema/schema.go
+++ b/gateway/schema/schema.go
@@ -85,6 +85,7 @@ func (g *Gateway) generateGraphqlSchema() error {
 	}
 
 	g.AddTypeByCategoryQuery(rootQueryFields)
+	g.addApplyYamlMutation(rootMutationFields)
 
 	newSchema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
@@ -790,4 +791,19 @@ func sanitizeFieldName(name string) string {
 	}
 
 	return name
+}
+
+// addApplyYamlMutation adds the static applyYaml mutation to root mutations.
+func (g *Gateway) addApplyYamlMutation(rootMutationFields graphql.Fields) {
+	args := resolver.NewFieldConfigArguments().
+		WithYaml().
+		WithDryRun().
+		Complete()
+
+	rootMutationFields["applyYaml"] = &graphql.Field{
+		Type:        jsonStringScalar,
+		Args:        args,
+		Resolve:     g.resolver.ApplyYaml(),
+		Description: "Apply a Kubernetes resource from YAML (creates if not exists, updates if exists)",
+	}
 }


### PR DESCRIPTION
## Summary

- Add `applyYaml` GraphQL mutation that applies Kubernetes resources directly from YAML input
- Uses get-then-update/create semantics: checks if resource exists, then updates or creates accordingly
- Supports dry-run validation via `dryRun` argument
- Includes comprehensive table-driven tests and documentation