### PR TITLE
chore: standardize repository files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,3 @@ All the released versions will be available through access to GitHub (as any oth
 ## Security / Disclosure
 
 If you find any bug that may be a security problem, please follow our instructions [in our security policy](https://github.com/platform-mesh/.github/blob/main/SECURITY.md) on how to report it. Please do not create GitHub issues for security-related doubts or problems.
-
-## Licensing
-
-Copyright 2025 SAP SE or an SAP affiliate company and platform-mesh contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/platform-mesh/kubernetes-graphql-gateway).
-


### PR DESCRIPTION
## Summary

- Removed `## Licensing` section (SAP SE copyright) from README

## Context

Repository governance files are being centralized in [platform-mesh/.github](https://github.com/platform-mesh/.github).