### PR TITLE
fix: implement health checks and gRPC reconnect logic in gateway

### DIFF
--- a/gateway/config.go
+++ b/gateway/config.go
@@ -44,7 +44,6 @@ func NewConfig(opts *options.CompletedOptions) (*Config, error) {
 
 	httpServer, err := http.NewServer(http.ServerConfig{
 		Gateway:                  gatewayServer,
-		HealthzCheck:             gatewayServer.IsHealthy,
 		ReadyzCheck:              gatewayServer.IsReady,
 		Addr:                     fmt.Sprintf("%s:%d", cfg.Options.ServerBindAddress, cfg.Options.ServerBindPort),
 		MaxRequestBodyBytes:      cfg.Options.MaxRequestBodyBytes,

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -44,6 +44,8 @@ func NewConfig(opts *options.CompletedOptions) (*Config, error) {
 
 	httpServer, err := http.NewServer(http.ServerConfig{
 		Gateway:                  gatewayServer,
+		HealthzCheck:             gatewayServer.IsHealthy,
+		ReadyzCheck:              gatewayServer.IsReady,
 		Addr:                     fmt.Sprintf("%s:%d", cfg.Options.ServerBindAddress, cfg.Options.ServerBindPort),
 		MaxRequestBodyBytes:      cfg.Options.MaxRequestBodyBytes,
 		MaxInFlightRequests:      cfg.Options.MaxInFlightRequests,

--- a/gateway/gateway/server.go
+++ b/gateway/gateway/server.go
@@ -133,13 +133,3 @@ func (s *Service) IsReady(_ *http.Request) error {
 	return nil
 }
 
-// IsHealthy reports whether the gateway is in a healthy state.
-// For file watcher mode this always returns nil.
-// For gRPC mode this returns an error when the stream is not active.
-// Compatible with healthz.Checker signature.
-func (s *Service) IsHealthy(_ *http.Request) error {
-	if s.config.SchemaHandler == "grpc" && !s.connected.Load() {
-		return fmt.Errorf("gRPC stream not connected")
-	}
-	return nil
-}

--- a/gateway/gateway/server.go
+++ b/gateway/gateway/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/config"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/registry"
@@ -21,6 +22,7 @@ type Service struct {
 	started   bool
 	ready     chan struct{}
 	readyOnce sync.Once
+	connected atomic.Bool
 }
 
 // New creates a new Gateway service.
@@ -52,6 +54,7 @@ func (s *Service) Run(ctx context.Context) error {
 		gw, err := watcher.NewGRPCWatcher(
 			watcher.GRPCWatcherConfig{Address: s.config.GRPCAddress},
 			s.registry,
+			&s.connected,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create gRPC watcher: %w", err)
@@ -114,4 +117,26 @@ func (s *Service) WaitForReady(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// IsReady reports whether the gateway has completed initial setup.
+// Compatible with healthz.Checker signature.
+func (s *Service) IsReady(_ *http.Request) error {
+	select {
+	case <-s.ready:
+		return nil
+	default:
+		return fmt.Errorf("gateway not ready")
+	}
+}
+
+// IsHealthy reports whether the gateway is in a healthy state.
+// For file watcher mode this always returns nil.
+// For gRPC mode this returns an error when the stream is not active.
+// Compatible with healthz.Checker signature.
+func (s *Service) IsHealthy(_ *http.Request) error {
+	if s.config.SchemaHandler == "grpc" && !s.connected.Load() {
+		return fmt.Errorf("gRPC stream not connected")
+	}
+	return nil
 }

--- a/gateway/gateway/server.go
+++ b/gateway/gateway/server.go
@@ -124,10 +124,13 @@ func (s *Service) WaitForReady(ctx context.Context) error {
 func (s *Service) IsReady(_ *http.Request) error {
 	select {
 	case <-s.ready:
-		return nil
 	default:
 		return fmt.Errorf("gateway not ready")
 	}
+	if s.config.SchemaHandler == "grpc" && !s.connected.Load() {
+		return fmt.Errorf("gRPC stream not connected")
+	}
+	return nil
 }
 
 // IsHealthy reports whether the gateway is in a healthy state.

--- a/gateway/gateway/watcher/grpc.go
+++ b/gateway/gateway/watcher/grpc.go
@@ -4,20 +4,25 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync/atomic"
+	"time"
 
 	"github.com/platform-mesh/kubernetes-graphql-gateway/sdk"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // GRPCWatcher watches for schema changes via gRPC streaming from a listener.
 // It implements the Watcher interface.
 type GRPCWatcher struct {
-	conn    *grpc.ClientConn
-	client  sdk.SchemaHandlerClient
-	handler SchemaEventHandler
+	conn      *grpc.ClientConn
+	client    sdk.SchemaHandlerClient
+	handler   SchemaEventHandler
+	connected *atomic.Bool
 }
 
 // GRPCWatcherConfig holds configuration for the gRPC watcher.
@@ -28,7 +33,7 @@ type GRPCWatcherConfig struct {
 
 // NewGRPCWatcher creates a new gRPC watcher that connects to the given address
 // and notifies the handler when schemas change.
-func NewGRPCWatcher(config GRPCWatcherConfig, handler SchemaEventHandler) (*GRPCWatcher, error) {
+func NewGRPCWatcher(config GRPCWatcherConfig, handler SchemaEventHandler, connected *atomic.Bool) (*GRPCWatcher, error) {
 	// TODO: Add proper TLS configuration for production
 	conn, err := grpc.NewClient(
 		config.Address,
@@ -41,9 +46,10 @@ func NewGRPCWatcher(config GRPCWatcherConfig, handler SchemaEventHandler) (*GRPC
 	client := sdk.NewSchemaHandlerClient(conn)
 
 	return &GRPCWatcher{
-		conn:    conn,
-		client:  client,
-		handler: handler,
+		conn:      conn,
+		client:    client,
+		handler:   handler,
+		connected: connected,
 	}, nil
 }
 
@@ -56,7 +62,8 @@ func (w *GRPCWatcher) Close() error {
 }
 
 // Run starts the gRPC watcher and blocks until the context is cancelled.
-// It subscribes to schema updates from the listener and processes them.
+// It subscribes to schema updates from the listener and automatically
+// reconnects on stream errors.
 func (w *GRPCWatcher) Run(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 	defer func() {
@@ -65,21 +72,47 @@ func (w *GRPCWatcher) Run(ctx context.Context) error {
 		}
 	}()
 
-	stream, err := w.client.Subscribe(ctx, &sdk.SubscribeRequest{})
+	// Uses exponential backoff with jitter to retry subscribe whenever
+	// the stream breaks. Stops when ctx is cancelled.
+	backoff := wait.Backoff{
+		Duration: 800 * time.Millisecond,
+		Cap:      30 * time.Second,
+		Steps:    10,
+		Factor:   2.0,
+		Jitter:   1.0,
+	}
+	delay := backoff.DelayWithReset(&clock.RealClock{}, 2*time.Minute)
+
+	return delay.Until(ctx, true, true, func(ctx context.Context) (bool, error) {
+		if err := w.subscribe(ctx); err != nil {
+			logger.Error(err, "gRPC stream error, reconnecting")
+		}
+		return false, nil
+	})
+}
+
+// subscribe establishes a gRPC stream and processes messages until
+// the stream breaks or the context is cancelled.
+func (w *GRPCWatcher) subscribe(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+
+	// WaitForReady makes Subscribe block until the connection is established
+	// instead of failing immediately when the server is not yet reachable.
+	stream, err := w.client.Subscribe(ctx, &sdk.SubscribeRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		return fmt.Errorf("failed to subscribe to schema updates: %w", err)
 	}
 
 	logger.Info("Connected to gRPC schema handler, waiting for updates")
+	w.connected.Store(true)
+	defer w.connected.Store(false)
 
 	for {
 		res, err := stream.Recv()
 		if err == io.EOF {
-			logger.Info("gRPC stream closed by server")
-			return nil
+			return fmt.Errorf("stream closed by server")
 		}
 		if err != nil {
-			// Check if context was cancelled
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}

--- a/gateway/gateway/watcher/grpc_test.go
+++ b/gateway/gateway/watcher/grpc_test.go
@@ -1,0 +1,272 @@
+package watcher_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/watcher"
+	proto "github.com/platform-mesh/kubernetes-graphql-gateway/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeHandler records schema events from the watcher.
+type fakeHandler struct {
+	mu       sync.Mutex
+	changed  map[string][]byte
+	deleted  []string
+	changeCh chan string
+}
+
+func newFakeHandler() *fakeHandler {
+	return &fakeHandler{
+		changed:  make(map[string][]byte),
+		changeCh: make(chan string, 10),
+	}
+}
+
+func (h *fakeHandler) OnSchemaChanged(_ context.Context, cluster string, schema []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.changed[cluster] = schema
+	h.changeCh <- cluster
+}
+
+func (h *fakeHandler) OnSchemaDeleted(_ context.Context, cluster string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.deleted = append(h.deleted, cluster)
+}
+
+// fakeSchemaServer is a gRPC server that can control stream behavior.
+type fakeSchemaServer struct {
+	proto.UnimplementedSchemaHandlerServer
+	mu          sync.Mutex
+	subscribers []proto.SchemaHandler_SubscribeServer
+	subscribeCh chan struct{}
+}
+
+func newFakeSchemaServer() *fakeSchemaServer {
+	return &fakeSchemaServer{
+		subscribeCh: make(chan struct{}, 10),
+	}
+}
+
+func (s *fakeSchemaServer) Subscribe(_ *proto.SubscribeRequest, stream proto.SchemaHandler_SubscribeServer) error {
+	s.mu.Lock()
+	s.subscribers = append(s.subscribers, stream)
+	s.mu.Unlock()
+
+	s.subscribeCh <- struct{}{}
+
+	// Block until client disconnects
+	<-stream.Context().Done()
+	return nil
+}
+
+func (s *fakeSchemaServer) send(resp *proto.SubscribeResponse) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, sub := range s.subscribers {
+		if err := sub.Send(resp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func startFakeServer(t *testing.T) (*fakeSchemaServer, string) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	fake := newFakeSchemaServer()
+	proto.RegisterSchemaHandlerServer(srv, fake)
+
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(func() { srv.GracefulStop() })
+
+	return fake, lis.Addr().String()
+}
+
+func TestGRPCWatcher_ConnectsAndReceives(t *testing.T) {
+	fake, addr := startFakeServer(t)
+	handler := newFakeHandler()
+	var connected atomic.Bool
+
+	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: addr}, handler, &connected)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		_ = gw.Run(ctx)
+	}()
+
+	// Wait for subscription
+	select {
+	case <-fake.subscribeCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for subscribe")
+	}
+
+	assert.True(t, connected.Load())
+
+	// Send a schema update
+	err = fake.send(&proto.SubscribeResponse{
+		ClusterName: "test-cluster",
+		Schema:      []byte("schema-data"),
+		EventType:   proto.SubscribeResponse_CREATED,
+	})
+	require.NoError(t, err)
+
+	select {
+	case cluster := <-handler.changeCh:
+		assert.Equal(t, "test-cluster", cluster)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for schema change")
+	}
+
+	cancel()
+}
+
+func TestGRPCWatcher_WaitsForServer(t *testing.T) {
+	// Start watcher before server is up — it should wait and connect once server starts.
+	handler := newFakeHandler()
+	var connected atomic.Bool
+
+	// Pick a port but don't listen on it yet
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+	_ = lis.Close() // free the port
+
+	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: addr}, handler, &connected)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		_ = gw.Run(ctx)
+	}()
+
+	// Watcher should not be connected yet
+	time.Sleep(100 * time.Millisecond)
+	assert.False(t, connected.Load())
+
+	// Now start the server on the same address
+	lis2, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	fake := newFakeSchemaServer()
+	proto.RegisterSchemaHandlerServer(srv, fake)
+	go func() {
+		_ = srv.Serve(lis2)
+	}()
+	t.Cleanup(func() { srv.GracefulStop() })
+
+	// Wait for subscribe
+	select {
+	case <-fake.subscribeCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for subscribe after server started")
+	}
+
+	assert.True(t, connected.Load())
+	cancel()
+}
+
+func TestGRPCWatcher_ContextCancellation(t *testing.T) {
+	handler := newFakeHandler()
+	var connected atomic.Bool
+
+	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: "127.0.0.1:0"}, handler, &connected)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- gw.Run(ctx)
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Run to return after cancel")
+	}
+}
+
+// failOnceServer returns an error on the first Subscribe call, then works normally.
+type failOnceServer struct {
+	proto.UnimplementedSchemaHandlerServer
+	mu          sync.Mutex
+	callCount   int
+	subscribeCh chan struct{}
+}
+
+func (s *failOnceServer) Subscribe(_ *proto.SubscribeRequest, stream proto.SchemaHandler_SubscribeServer) error {
+	s.mu.Lock()
+	s.callCount++
+	count := s.callCount
+	s.mu.Unlock()
+
+	if count == 1 {
+		return status.Error(codes.Unavailable, "not ready yet")
+	}
+
+	s.subscribeCh <- struct{}{}
+	<-stream.Context().Done()
+	return nil
+}
+
+func TestGRPCWatcher_RetriesAfterSubscribeError(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	fake := &failOnceServer{subscribeCh: make(chan struct{}, 1)}
+	srv := grpc.NewServer()
+	proto.RegisterSchemaHandlerServer(srv, fake)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(func() { srv.GracefulStop() })
+
+	handler := newFakeHandler()
+	var connected atomic.Bool
+	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: lis.Addr().String()}, handler, &connected)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		_ = gw.Run(ctx)
+	}()
+
+	// Should eventually connect after the first failure
+	select {
+	case <-fake.subscribeCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for retry subscribe")
+	}
+
+	assert.True(t, connected.Load())
+	cancel()
+}

--- a/gateway/gateway/watcher/grpc_test.go
+++ b/gateway/gateway/watcher/grpc_test.go
@@ -13,15 +13,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // fakeHandler records schema events from the watcher.
 type fakeHandler struct {
 	mu       sync.Mutex
 	changed  map[string][]byte
-	deleted  []string
 	changeCh chan string
 }
 
@@ -42,21 +39,59 @@ func (h *fakeHandler) OnSchemaChanged(_ context.Context, cluster string, schema 
 func (h *fakeHandler) OnSchemaDeleted(_ context.Context, cluster string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.deleted = append(h.deleted, cluster)
 }
 
-// fakeSchemaServer is a gRPC server that can control stream behavior.
+func TestGRPCWatcher_ConnectsAndReceives(t *testing.T) {
+	// Start a fake gRPC schema server
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	fake := &fakeSchemaServer{subscribeCh: make(chan struct{}, 10)}
+	srv := grpc.NewServer()
+	proto.RegisterSchemaHandlerServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() { srv.GracefulStop() })
+
+	handler := newFakeHandler()
+	var connected atomic.Bool
+
+	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: lis.Addr().String()}, handler, &connected)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() { _ = gw.Run(ctx) }()
+
+	// Wait for subscription to be established
+	select {
+	case <-fake.subscribeCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for subscribe")
+	}
+	assert.True(t, connected.Load())
+
+	// Send a schema update and verify it arrives
+	require.NoError(t, fake.send(&proto.SubscribeResponse{
+		ClusterName: "test-cluster",
+		Schema:      []byte("schema-data"),
+		EventType:   proto.SubscribeResponse_CREATED,
+	}))
+
+	select {
+	case cluster := <-handler.changeCh:
+		assert.Equal(t, "test-cluster", cluster)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for schema change")
+	}
+}
+
+// fakeSchemaServer implements the Subscribe RPC for testing.
 type fakeSchemaServer struct {
 	proto.UnimplementedSchemaHandlerServer
 	mu          sync.Mutex
 	subscribers []proto.SchemaHandler_SubscribeServer
 	subscribeCh chan struct{}
-}
-
-func newFakeSchemaServer() *fakeSchemaServer {
-	return &fakeSchemaServer{
-		subscribeCh: make(chan struct{}, 10),
-	}
 }
 
 func (s *fakeSchemaServer) Subscribe(_ *proto.SubscribeRequest, stream proto.SchemaHandler_SubscribeServer) error {
@@ -65,8 +100,6 @@ func (s *fakeSchemaServer) Subscribe(_ *proto.SubscribeRequest, stream proto.Sch
 	s.mu.Unlock()
 
 	s.subscribeCh <- struct{}{}
-
-	// Block until client disconnects
 	<-stream.Context().Done()
 	return nil
 }
@@ -80,193 +113,4 @@ func (s *fakeSchemaServer) send(resp *proto.SubscribeResponse) error {
 		}
 	}
 	return nil
-}
-
-func startFakeServer(t *testing.T) (*fakeSchemaServer, string) {
-	t.Helper()
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	srv := grpc.NewServer()
-	fake := newFakeSchemaServer()
-	proto.RegisterSchemaHandlerServer(srv, fake)
-
-	go func() {
-		_ = srv.Serve(lis)
-	}()
-	t.Cleanup(func() { srv.GracefulStop() })
-
-	return fake, lis.Addr().String()
-}
-
-func TestGRPCWatcher_ConnectsAndReceives(t *testing.T) {
-	fake, addr := startFakeServer(t)
-	handler := newFakeHandler()
-	var connected atomic.Bool
-
-	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: addr}, handler, &connected)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	go func() {
-		_ = gw.Run(ctx)
-	}()
-
-	// Wait for subscription
-	select {
-	case <-fake.subscribeCh:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for subscribe")
-	}
-
-	assert.True(t, connected.Load())
-
-	// Send a schema update
-	err = fake.send(&proto.SubscribeResponse{
-		ClusterName: "test-cluster",
-		Schema:      []byte("schema-data"),
-		EventType:   proto.SubscribeResponse_CREATED,
-	})
-	require.NoError(t, err)
-
-	select {
-	case cluster := <-handler.changeCh:
-		assert.Equal(t, "test-cluster", cluster)
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for schema change")
-	}
-
-	cancel()
-}
-
-func TestGRPCWatcher_WaitsForServer(t *testing.T) {
-	// Start watcher before server is up — it should wait and connect once server starts.
-	handler := newFakeHandler()
-	var connected atomic.Bool
-
-	// Pick a port but don't listen on it yet
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := lis.Addr().String()
-	_ = lis.Close() // free the port
-
-	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: addr}, handler, &connected)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	go func() {
-		_ = gw.Run(ctx)
-	}()
-
-	// Watcher should not be connected yet
-	time.Sleep(100 * time.Millisecond)
-	assert.False(t, connected.Load())
-
-	// Now start the server on the same address
-	lis2, err := net.Listen("tcp", addr)
-	require.NoError(t, err)
-
-	srv := grpc.NewServer()
-	fake := newFakeSchemaServer()
-	proto.RegisterSchemaHandlerServer(srv, fake)
-	go func() {
-		_ = srv.Serve(lis2)
-	}()
-	t.Cleanup(func() { srv.GracefulStop() })
-
-	// Wait for subscribe
-	select {
-	case <-fake.subscribeCh:
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for subscribe after server started")
-	}
-
-	assert.True(t, connected.Load())
-	cancel()
-}
-
-func TestGRPCWatcher_ContextCancellation(t *testing.T) {
-	handler := newFakeHandler()
-	var connected atomic.Bool
-
-	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: "127.0.0.1:0"}, handler, &connected)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(t.Context())
-
-	done := make(chan error, 1)
-	go func() {
-		done <- gw.Run(ctx)
-	}()
-
-	cancel()
-
-	select {
-	case err := <-done:
-		assert.ErrorIs(t, err, context.Canceled)
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for Run to return after cancel")
-	}
-}
-
-// failOnceServer returns an error on the first Subscribe call, then works normally.
-type failOnceServer struct {
-	proto.UnimplementedSchemaHandlerServer
-	mu          sync.Mutex
-	callCount   int
-	subscribeCh chan struct{}
-}
-
-func (s *failOnceServer) Subscribe(_ *proto.SubscribeRequest, stream proto.SchemaHandler_SubscribeServer) error {
-	s.mu.Lock()
-	s.callCount++
-	count := s.callCount
-	s.mu.Unlock()
-
-	if count == 1 {
-		return status.Error(codes.Unavailable, "not ready yet")
-	}
-
-	s.subscribeCh <- struct{}{}
-	<-stream.Context().Done()
-	return nil
-}
-
-func TestGRPCWatcher_RetriesAfterSubscribeError(t *testing.T) {
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	fake := &failOnceServer{subscribeCh: make(chan struct{}, 1)}
-	srv := grpc.NewServer()
-	proto.RegisterSchemaHandlerServer(srv, fake)
-	go func() {
-		_ = srv.Serve(lis)
-	}()
-	t.Cleanup(func() { srv.GracefulStop() })
-
-	handler := newFakeHandler()
-	var connected atomic.Bool
-	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: lis.Addr().String()}, handler, &connected)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	go func() {
-		_ = gw.Run(ctx)
-	}()
-
-	// Should eventually connect after the first failure
-	select {
-	case <-fake.subscribeCh:
-	case <-time.After(15 * time.Second):
-		t.Fatal("timed out waiting for retry subscribe")
-	}
-
-	assert.True(t, connected.Load())
-	cancel()
 }

--- a/gateway/http/http.go
+++ b/gateway/http/http.go
@@ -13,11 +13,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type ServerConfig struct {
 	Gateway http.Handler
+
+	// HealthzCheck and ReadyzCheck are optional controller-runtime healthz.Checker
+	// functions. When set, they are used by /healthz and /readyz respectively.
+	// When nil, the endpoints always return 200.
+	HealthzCheck healthz.Checker
+	ReadyzCheck  healthz.Checker
 
 	CORSConfig CORSConfig
 
@@ -88,12 +95,8 @@ func NewServer(c ServerConfig) (*Server, error) {
 	// TODO: Add middleware for logging, metrics, tracing, etc.
 
 	// Health and metrics endpoints
-	s.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	s.Handle("/readyz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	s.Handle("/healthz", healthz.CheckHandler{Checker: checkerOrPing(c.HealthzCheck)})
+	s.Handle("/readyz", healthz.CheckHandler{Checker: checkerOrPing(c.ReadyzCheck)})
 	s.Handle("/metrics", promhttp.Handler())
 
 	corsHandler := cors.New(cors.Options{
@@ -110,6 +113,14 @@ func NewServer(c ServerConfig) (*Server, error) {
 			IdleTimeout:       c.IdleTimeout,
 		},
 	}, nil
+}
+
+// checkerOrPing returns the given checker if non-nil, otherwise healthz.Ping (always healthy).
+func checkerOrPing(c healthz.Checker) healthz.Checker {
+	if c != nil {
+		return c
+	}
+	return healthz.Ping
 }
 
 func (s *Server) Run(ctx context.Context) error {

--- a/gateway/http/http.go
+++ b/gateway/http/http.go
@@ -95,7 +95,7 @@ func NewServer(c ServerConfig) (*Server, error) {
 	// TODO: Add middleware for logging, metrics, tracing, etc.
 
 	// Health and metrics endpoints
-	s.Handle("/healthz", healthz.CheckHandler{Checker: checkerOrPing(c.HealthzCheck)})
+	s.Handle("/healthz", healthz.CheckHandler{Checker: healthz.Ping})
 	s.Handle("/readyz", healthz.CheckHandler{Checker: checkerOrPing(c.ReadyzCheck)})
 	s.Handle("/metrics", promhttp.Handler())
 

--- a/gateway/http/http_test.go
+++ b/gateway/http/http_test.go
@@ -136,6 +136,28 @@ func TestUnauthenticatedEndpoints(t *testing.T) {
 	}
 }
 
+func TestHealthEndpointsReflectCheckerState(t *testing.T) {
+	failing := func(_ *http.Request) error { return fmt.Errorf("down") }
+
+	srv, err := NewServer(ServerConfig{
+		Gateway:        &captureHandler{},
+		HealthzCheck:   failing,
+		ReadyzCheck:    failing,
+		Addr:           ":0",
+		EndpointSuffix: testEndpointSuffix,
+	})
+	require.NoError(t, err)
+	ts := httptest.NewServer(srv.Server.Handler)
+	defer ts.Close()
+
+	for _, path := range []string{"/healthz", "/readyz"} {
+		resp, err := http.Get(ts.URL + path)
+		require.NoError(t, err)
+		resp.Body.Close() //nolint:errcheck
+		assert.NotEqual(t, http.StatusOK, resp.StatusCode, path)
+	}
+}
+
 func TestMaxRequestBodyBytes(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/gateway/http/http_test.go
+++ b/gateway/http/http_test.go
@@ -150,7 +150,7 @@ func TestHealthEndpointsReflectCheckerState(t *testing.T) {
 	ts := httptest.NewServer(srv.Server.Handler)
 	defer ts.Close()
 
-	for _, path := range []string{"/healthz", "/readyz"} {
+	for _, path := range []string{"/readyz"} {
 		resp, err := http.Get(ts.URL + path)
 		require.NoError(t, err)
 		resp.Body.Close() //nolint:errcheck


### PR DESCRIPTION
There is currently a problem when starting the gateway in grpc mode. If the listener is not already available the gateway will not attempt to reconnect, so it will report healthy despite being unready.

This PR fixes that so that in case the grpc mode is active, the gateway is only healthy if an actual connection is established.