### PR TITLE
feat(crd): make ClusterAccess host field optional

### DIFF
--- a/apis/v1alpha1/clusteraccess_types.go
+++ b/apis/v1alpha1/clusteraccess_types.go
@@ -24,8 +24,9 @@ type ClusterAccessSpec struct {
 	// +optional
 	Path string `json:"path,omitempty"`
 
-	// Host is the URL for the cluster
-	Host string `json:"host"`
+	// Host is the URL for the cluster. If not set and kubeconfig auth is used, the host from the kubeconfig is used.
+	// +optional
+	Host string `json:"host,omitempty"`
 
 	// CA configuration for the cluster
 	// +optional

--- a/apis/v1alpha1/clustermetadata_types.go
+++ b/apis/v1alpha1/clustermetadata_types.go
@@ -126,6 +126,18 @@ func buildClusterMetadataFromClusterAccess(ctx context.Context, ca ClusterAccess
 			Type:       AuthTypeKubeconfig,
 			Kubeconfig: base64.StdEncoding.EncodeToString(kubeconfigData),
 		}
+		// If host is not explicitly set, derive it from the kubeconfig
+		if metadata.Host == "" {
+			clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfigData)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse kubeconfig for host extraction: %w", err)
+			}
+			cfg, err := clientConfig.ClientConfig()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get client config from kubeconfig: %w", err)
+			}
+			metadata.Host = cfg.Host
+		}
 
 	case auth.ClientCertificateRef != nil:
 		secret := &corev1.Secret{}
@@ -236,10 +248,6 @@ func BuildRestConfigFromClusterAccess(ctx context.Context, ca ClusterAccess, c c
 
 // buildConfigFromMetadata creates a rest.Config from base64-encoded metadata (used by gateway)
 func buildConfigFromMetadata(metadata ClusterMetadata) (*rest.Config, error) {
-	if metadata.Host == "" {
-		return nil, errors.New("host is required")
-	}
-
 	config := &rest.Config{
 		Host: metadata.Host,
 		TLSClientConfig: rest.TLSClientConfig{
@@ -306,7 +314,13 @@ func buildConfigFromMetadata(metadata ClusterMetadata) (*rest.Config, error) {
 		}
 	}
 
-	config.Host = metadata.Host
+	if metadata.Host != "" {
+		config.Host = metadata.Host
+	}
+
+	if config.Host == "" {
+		return nil, errors.New("host must be set either in spec or derived from kubeconfig")
+	}
 
 	return config, nil
 }

--- a/config/crd/gateway.platform-mesh.io_clusteraccesses.yaml
+++ b/config/crd/gateway.platform-mesh.io_clusteraccesses.yaml
@@ -141,14 +141,13 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               host:
-                description: Host is the URL for the cluster
+                description: Host is the URL for the cluster. If not set and kubeconfig
+                  auth is used, the host from the kubeconfig is used.
                 type: string
               path:
                 description: Path is an optional field. If not set, the name of the
                   resource is used
                 type: string
-            required:
-            - host
             type: object
           status:
             description: ClusterAccessStatus defines the observed state of ClusterAccess.

--- a/config/kcp/apiexport-gateway.platform-mesh.io.yaml
+++ b/config/kcp/apiexport-gateway.platform-mesh.io.yaml
@@ -10,7 +10,7 @@ spec:
   resources:
   - group: gateway.platform-mesh.io
     name: clusteraccesses
-    schema: v260310-87011ac.clusteraccesses.gateway.platform-mesh.io
+    schema: v260409-a121c30.clusteraccesses.gateway.platform-mesh.io
     storage:
       crd: {}
 status: {}

--- a/config/kcp/apiresourceschema-clusteraccesses.gateway.platform-mesh.io.yaml
+++ b/config/kcp/apiresourceschema-clusteraccesses.gateway.platform-mesh.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260310-87011ac.clusteraccesses.gateway.platform-mesh.io
+  name: v260409-a121c30.clusteraccesses.gateway.platform-mesh.io
 spec:
   group: gateway.platform-mesh.io
   names:
@@ -136,14 +136,13 @@ spec:
                   x-kubernetes-map-type: atomic
               type: object
             host:
-              description: Host is the URL for the cluster
+              description: Host is the URL for the cluster. If not set and kubeconfig
+                auth is used, the host from the kubeconfig is used.
               type: string
             path:
               description: Path is an optional field. If not set, the name of the
                 resource is used
               type: string
-          required:
-          - host
           type: object
         status:
           description: ClusterAccessStatus defines the observed state of ClusterAccess.

--- a/gateway/gateway/middleware/timeout.go
+++ b/gateway/gateway/middleware/timeout.go
@@ -53,11 +53,11 @@ func WithTimeout(handler http.Handler, timeout time.Duration) http.Handler {
 
 // timeoutWriter buffers the response so it can be discarded on timeout.
 type timeoutWriter struct {
-	wrapped http.ResponseWriter
-	header  http.Header
-	buf     bytes.Buffer
-	code    int
-	mu      sync.Mutex
+	wrapped  http.ResponseWriter
+	header   http.Header
+	buf      bytes.Buffer
+	code     int
+	mu       sync.Mutex
 	timedOut bool
 	flusher  http.Flusher // resolved once at construction; nil if unsupported
 }

--- a/listener/controllers/clusteraccess/clusteraccess_controller.go
+++ b/listener/controllers/clusteraccess/clusteraccess_controller.go
@@ -227,11 +227,6 @@ func (r *ClusterAccessReconciler) SetupWithManager(mgr mcmanager.Manager, forOpt
 func buildTargetClusterConfig(ctx context.Context, clusterAccess v1alpha1.ClusterAccess, c client.Client, currentConfig *rest.Config) (*rest.Config, error) {
 	spec := clusterAccess.Spec
 
-	host := spec.Host
-	if host == "" {
-		return nil, errors.New("host field not found in ClusterAccess spec")
-	}
-
 	config, err := v1alpha1.BuildRestConfigFromClusterAccess(ctx, clusterAccess, c)
 	if err != nil {
 		return nil, err
@@ -242,7 +237,9 @@ func buildTargetClusterConfig(ctx context.Context, clusterAccess v1alpha1.Cluste
 		config.Insecure = false
 	}
 
-	config.Host = host
+	if spec.Host != "" {
+		config.Host = spec.Host
+	}
 
 	return config, nil
 }

--- a/listener/controllers/clusteraccess/clusteraccess_controller_test.go
+++ b/listener/controllers/clusteraccess/clusteraccess_controller_test.go
@@ -276,6 +276,49 @@ func (suite *ClusterAccessControllerTestSuite) TestKubeconfigAuth() {
 	suite.verifySchemaMetadata("single-kubeconfig-test", v1alpha1.AuthTypeKubeconfig)
 }
 
+// TestKubeconfigAuthWithoutHost tests ClusterAccess with kubeconfig authentication and no explicit host.
+// The host should be derived from the kubeconfig's server URL.
+func (suite *ClusterAccessControllerTestSuite) TestKubeconfigAuthWithoutHost() {
+	// Create secret with kubeconfig
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubeconfig-nohost-secret",
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"kubeconfig": suite.envtestKubeconfig,
+		},
+	}
+	err := suite.client.Create(context.Background(), kubeconfigSecret)
+	suite.Require().NoError(err, "failed to create kubeconfig secret")
+
+	// Create ClusterAccess without host — should derive it from kubeconfig
+	clusterAccess := &v1alpha1.ClusterAccess{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubeconfig-nohost-test",
+		},
+		Spec: v1alpha1.ClusterAccessSpec{
+			Auth: &v1alpha1.AuthConfig{
+				KubeconfigSecretRef: &v1alpha1.SecretKeyRef{
+					SecretReference: corev1.SecretReference{
+						Name:      "kubeconfig-nohost-secret",
+						Namespace: testNamespace,
+					},
+					Key: "kubeconfig",
+				},
+			},
+		},
+	}
+	err = suite.client.Create(context.Background(), clusterAccess)
+	suite.Require().NoError(err, "failed to create ClusterAccess")
+
+	// Wait for schema file to be generated
+	suite.waitForSchemaFile("single-kubeconfig-nohost-test")
+
+	// Verify schema metadata — host should have been derived from kubeconfig
+	suite.verifySchemaMetadata("single-kubeconfig-nohost-test", v1alpha1.AuthTypeKubeconfig)
+}
+
 // TestTokenAuth tests ClusterAccess with token authentication
 func (suite *ClusterAccessControllerTestSuite) TestTokenAuth() {
 	// First create a ServiceAccount to generate a token


### PR DESCRIPTION
## Summary

- Makes the `host` field optional in the ClusterAccess CRD
- When kubeconfig auth is used and `host` is omitted, the server URL is derived from the kubeconfig
- If `host` is explicitly set, it still takes precedence over the kubeconfig's server URL

This unblocks the virtual-workspaces Helm chart's new marketplace ClusterAccess resource, which only provides a kubeconfig reference without an explicit host.