### PR TITLE
chore: codify host comment

### DIFF
--- a/apis/v1alpha1/clusteraccess_types.go
+++ b/apis/v1alpha1/clusteraccess_types.go
@@ -19,6 +19,7 @@ type ClusterAccess struct {
 }
 
 // ClusterAccessSpec defines the desired state of ClusterAccess
+// +kubebuilder:validation:XValidation:rule="has(self.host) || (has(self.auth) && has(self.auth.kubeconfigSecretRef))",message="host is required unless kubeconfigSecretRef auth is used"
 type ClusterAccessSpec struct {
 	// Path is an optional field. If not set, the name of the resource is used
 	// +optional

--- a/config/crd/gateway.platform-mesh.io_clusteraccesses.yaml
+++ b/config/crd/gateway.platform-mesh.io_clusteraccesses.yaml
@@ -149,6 +149,9 @@ spec:
                   resource is used
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: host is required unless kubeconfigSecretRef auth is used
+              rule: has(self.host) || (has(self.auth) && has(self.auth.kubeconfigSecretRef))
           status:
             description: ClusterAccessStatus defines the observed state of ClusterAccess.
             properties:

--- a/config/kcp/apiexport-gateway.platform-mesh.io.yaml
+++ b/config/kcp/apiexport-gateway.platform-mesh.io.yaml
@@ -10,7 +10,7 @@ spec:
   resources:
   - group: gateway.platform-mesh.io
     name: clusteraccesses
-    schema: v260409-a121c30.clusteraccesses.gateway.platform-mesh.io
+    schema: v260410-a6fcb8b.clusteraccesses.gateway.platform-mesh.io
     storage:
       crd: {}
 status: {}

--- a/config/kcp/apiresourceschema-clusteraccesses.gateway.platform-mesh.io.yaml
+++ b/config/kcp/apiresourceschema-clusteraccesses.gateway.platform-mesh.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260409-a121c30.clusteraccesses.gateway.platform-mesh.io
+  name: v260410-a6fcb8b.clusteraccesses.gateway.platform-mesh.io
 spec:
   group: gateway.platform-mesh.io
   names:
@@ -144,6 +144,9 @@ spec:
                 resource is used
               type: string
           type: object
+          x-kubernetes-validations:
+          - message: host is required unless kubeconfigSecretRef auth is used
+            rule: has(self.host) || (has(self.auth) && has(self.auth.kubeconfigSecretRef))
         status:
           description: ClusterAccessStatus defines the observed state of ClusterAccess.
           properties:


### PR DESCRIPTION
Basically a small follow up to the previous PR making host optional but with a condition.

This PR codifies the condition so we sitll have proper validation by the api-server in place. The server now answers like this:

```
❯ k apply -f wrong.yaml
The ClusterAccess "local" is invalid: spec: Invalid value: host is required unless kubeconfigSecretRef auth is used
❯ k apply -f correct.yaml
clusteraccess.gateway.platform-mesh.io/local created
```