### PR TITLE
test: add CRD roundtrip and parser fuzz tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -115,6 +115,15 @@ tasks:
       - task: lint
       - task: test
 
+  fuzz:
+    desc: "Run fuzz tests with a configurable duration (default 30s per target)"
+    vars:
+      FUZZTIME: '{{.FUZZTIME | default "30s"}}'
+    cmds:
+      - go test ./apis/v1alpha1/ -run=^$ -fuzz=FuzzClusterAccessRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./gateway/gateway/queryvalidation/ -run=^$ -fuzz=FuzzQueryValidation -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./gateway/resolver/ -run=^$ -fuzz=FuzzParseAndValidateYAML -fuzztime={{.FUZZTIME}} -count=1
+
   proto:
     desc: "Generate protobuf files"
     cmds:

--- a/apis/v1alpha1/roundtrip_fuzz_test.go
+++ b/apis/v1alpha1/roundtrip_fuzz_test.go
@@ -1,0 +1,39 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func FuzzClusterAccessRoundTrip(f *testing.F) {
+	f.Add([]byte(`{"metadata":{"name":"test"},"spec":{"host":"https://example.com"}}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"spec":{"auth":{"tokenSecretRef":{"name":"s","namespace":"ns","key":"token"}}}}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzRoundTrip(t, data, &ClusterAccess{}, &ClusterAccess{})
+	})
+}
+
+func fuzzRoundTrip[T any](t *testing.T, data []byte, obj *T, obj2 *T) {
+	t.Helper()
+
+	if err := json.Unmarshal(data, obj); err != nil {
+		return
+	}
+
+	roundtripped, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	if err := json.Unmarshal(roundtripped, obj2); err != nil {
+		t.Fatalf("failed to unmarshal roundtripped data: %v", err)
+	}
+
+	if !equality.Semantic.DeepEqual(obj, obj2) {
+		t.Errorf("roundtrip mismatch for %T", obj)
+	}
+}

--- a/gateway/gateway/queryvalidation/queryvalidation_fuzz_test.go
+++ b/gateway/gateway/queryvalidation/queryvalidation_fuzz_test.go
@@ -1,0 +1,17 @@
+package queryvalidation
+
+import "testing"
+
+func FuzzQueryValidation(f *testing.F) {
+	f.Add("{ users { name } }")
+	f.Add("query { deeply { nested { query { that { goes { deep } } } } } }")
+	f.Add("")
+	f.Add("{")
+	f.Add("mutation { createPod { metadata { name } } }")
+	f.Add("query { ...F } fragment F on Query { a { b } }")
+
+	f.Fuzz(func(t *testing.T, query string) {
+		cfg := Config{MaxDepth: 10, MaxComplexity: 100}
+		_ = Validate(query, cfg)
+	})
+}

--- a/gateway/resolver/resolver_fuzz_test.go
+++ b/gateway/resolver/resolver_fuzz_test.go
@@ -1,0 +1,15 @@
+package resolver
+
+import "testing"
+
+func FuzzParseAndValidateYAML(f *testing.F) {
+	f.Add("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test")
+	f.Add("")
+	f.Add("invalid: [yaml")
+	f.Add("---\napiVersion: v1\nkind: Pod\nmetadata:\n  name: test\n  namespace: default")
+	f.Add("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: first\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: second")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		_, _ = parseAndValidateYAML(input)
+	})
+}


### PR DESCRIPTION
## Summary
- Add CRD roundtrip fuzz test for ClusterAccess
- Add GraphQL query validation fuzz test
- Add YAML parser fuzz test
- Add `task fuzz` entry to Taskfile for on-demand mutation fuzzing

Closes #208
Part of platform-mesh/backlog#231