### PR TITLE
feat: enhance ClusterAccess and ClusterMetadata with introspection and request path template

### DIFF
--- a/apis/v1alpha1/clusteraccess_types.go
+++ b/apis/v1alpha1/clusteraccess_types.go
@@ -29,6 +29,17 @@ type ClusterAccessSpec struct {
 	// +optional
 	Host string `json:"host,omitempty"`
 
+	// IntrospectionPath is an optional path suffix appended to Host when the listener
+	// performs API discovery/introspection (e.g. "/clusters/*").
+	// +optional
+	IntrospectionPath string `json:"introspectionPath,omitempty"`
+
+	// RequestPathTemplate defines a URL path template prepended to upstream API requests
+	// at gateway time. The {clusterTarget} variable is resolved from the GraphQL extensions
+	// field at request time. Example: "/clusters/{clusterTarget}"
+	// +optional
+	RequestPathTemplate string `json:"requestPathTemplate,omitempty"`
+
 	// CA configuration for the cluster
 	// +optional
 	CA *CAConfig `json:"ca,omitempty"`

--- a/apis/v1alpha1/clustermetadata_types.go
+++ b/apis/v1alpha1/clustermetadata_types.go
@@ -39,10 +39,12 @@ func DefaultClusterURLResolverFunc(url, clusterName string) (string, error) {
 
 // ClusterMetadata represents the cluster connection metadata stored in schema files.
 type ClusterMetadata struct {
-	Host string        `json:"host"`
-	Path string        `json:"path,omitempty"`
-	Auth *AuthMetadata `json:"auth,omitempty"`
-	CA   *CAMetadata   `json:"ca,omitempty"`
+	Host                string        `json:"host"`
+	Path                string        `json:"path,omitempty"`
+	RequestPathTemplate string        `json:"requestPathTemplate,omitempty"`
+	IntrospectionPath   string        `json:"introspectionPath,omitempty"`
+	Auth                *AuthMetadata `json:"auth,omitempty"`
+	CA                  *CAMetadata   `json:"ca,omitempty"`
 }
 
 type AuthenticationType string
@@ -85,8 +87,10 @@ func BuildClusterMetadataFromClusterAccess(ctx context.Context, ca ClusterAccess
 // buildClusterMetadataFromClusterAccess builds ClusterMetadata from ClusterAccess
 func buildClusterMetadataFromClusterAccess(ctx context.Context, ca ClusterAccess, c client.Client) (*ClusterMetadata, error) {
 	metadata := &ClusterMetadata{
-		Host: ca.Spec.Host,
-		Path: ca.Spec.Path,
+		Host:                ca.Spec.Host,
+		Path:                ca.Spec.Path,
+		RequestPathTemplate: ca.Spec.RequestPathTemplate,
+		IntrospectionPath:   ca.Spec.IntrospectionPath,
 	}
 
 	// Handle CA configuration

--- a/config/crd/gateway.platform-mesh.io_clusteraccesses.yaml
+++ b/config/crd/gateway.platform-mesh.io_clusteraccesses.yaml
@@ -144,9 +144,20 @@ spec:
                 description: Host is the URL for the cluster. If not set and kubeconfig
                   auth is used, the host from the kubeconfig is used.
                 type: string
+              introspectionPath:
+                description: |-
+                  IntrospectionPath is an optional path suffix appended to Host when the listener
+                  performs API discovery/introspection (e.g. "/clusters/*").
+                type: string
               path:
                 description: Path is an optional field. If not set, the name of the
                   resource is used
+                type: string
+              requestPathTemplate:
+                description: |-
+                  RequestPathTemplate defines a URL path template prepended to upstream API requests
+                  at gateway time. The {clusterTarget} variable is resolved from the GraphQL extensions
+                  field at request time. Example: "/clusters/{clusterTarget}"
                 type: string
             type: object
             x-kubernetes-validations:

--- a/config/kcp/apiexport-gateway.platform-mesh.io.yaml
+++ b/config/kcp/apiexport-gateway.platform-mesh.io.yaml
@@ -10,7 +10,7 @@ spec:
   resources:
   - group: gateway.platform-mesh.io
     name: clusteraccesses
-    schema: v260410-a6fcb8b.clusteraccesses.gateway.platform-mesh.io
+    schema: v260419-1b8ee42.clusteraccesses.gateway.platform-mesh.io
     storage:
       crd: {}
 status: {}

--- a/config/kcp/apiresourceschema-clusteraccesses.gateway.platform-mesh.io.yaml
+++ b/config/kcp/apiresourceschema-clusteraccesses.gateway.platform-mesh.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260410-a6fcb8b.clusteraccesses.gateway.platform-mesh.io
+  name: v260419-1b8ee42.clusteraccesses.gateway.platform-mesh.io
 spec:
   group: gateway.platform-mesh.io
   names:
@@ -139,9 +139,20 @@ spec:
               description: Host is the URL for the cluster. If not set and kubeconfig
                 auth is used, the host from the kubeconfig is used.
               type: string
+            introspectionPath:
+              description: |-
+                IntrospectionPath is an optional path suffix appended to Host when the listener
+                performs API discovery/introspection (e.g. "/clusters/*").
+              type: string
             path:
               description: Path is an optional field. If not set, the name of the
                 resource is used
+              type: string
+            requestPathTemplate:
+              description: |-
+                RequestPathTemplate defines a URL path template prepended to upstream API requests
+                at gateway time. The {clusterTarget} variable is resolved from the GraphQL extensions
+                field at request time. Example: "/clusters/{clusterTarget}"
               type: string
           type: object
           x-kubernetes-validations:

--- a/gateway/gateway/cluster/cluster.go
+++ b/gateway/gateway/cluster/cluster.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/platform-mesh/kubernetes-graphql-gateway/apis/v1alpha1"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/roundtripper"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/roundtripper/union"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -41,9 +45,14 @@ func New(
 		return nil, fmt.Errorf("failed to build config from metadata: %w", err)
 	}
 
-	// Save a copy before Wrap() mutates the transport — callers that need
-	// admin-credential access (e.g. TokenReview) use this config.
 	cluster.adminCfg = rest.CopyConfig(cluster.restCfg)
+
+	basePath := hostPath(metadata.Host)
+	tpl := metadata.RequestPathTemplate
+
+	cluster.adminCfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return roundtripper.NewPathTemplateHandler(rt, tpl, basePath)
+	})
 
 	tlsConfig := cluster.restCfg.TLSClientConfig
 	baseRT, err := roundtripper.NewBaseRoundTripper(tlsConfig)
@@ -51,14 +60,23 @@ func New(
 		return nil, fmt.Errorf("failed to create base roundtripper: %w", err)
 	}
 
+	dataPlanePrefix := basePath + tpl
 	cluster.restCfg.Wrap(func(adminRT http.RoundTripper) http.RoundTripper {
 		return union.New(
-			roundtripper.NewDiscoveryHandler(adminRT),
-			roundtripper.NewBearerHandler(baseRT, roundtripper.NewUnauthorizedRoundTripper()),
+			roundtripper.NewDiscoveryHandler(roundtripper.NewPathTemplateHandler(adminRT, dataPlanePrefix, basePath)),
+			roundtripper.NewBearerHandler(roundtripper.NewPathTemplateHandler(baseRT, dataPlanePrefix, basePath), roundtripper.NewUnauthorizedRoundTripper()),
 		)
 	})
 
-	cluster.client, err = client.NewWithWatch(cluster.restCfg, client.Options{})
+	var mapper meta.RESTMapper
+	if metadata.IntrospectionPath != "" {
+		mapper, err = restMapperFromConfig(cluster.adminCfg, metadata.IntrospectionPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create REST mapper: %w", err)
+		}
+	}
+
+	cluster.client, err = client.NewWithWatch(cluster.restCfg, client.Options{Mapper: mapper})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cluster client: %w", err)
 	}
@@ -83,4 +101,23 @@ func (c *Cluster) Close() {
 	c.client = nil
 	c.adminCfg = nil
 	c.restCfg = nil
+}
+
+func hostPath(host string) string {
+	u, err := url.Parse(host)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(u.Path, "/")
+}
+
+func restMapperFromConfig(cfg *rest.Config, introspectionPath string) (meta.RESTMapper, error) {
+	discoveryCfg := rest.CopyConfig(cfg)
+	discoveryCfg.Host += introspectionPath
+
+	httpClient, err := rest.HTTPClientFor(discoveryCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client for discovery: %w", err)
+	}
+	return apiutil.NewDynamicRESTMapper(discoveryCfg, httpClient)
 }

--- a/gateway/gateway/endpoint/endpoint.go
+++ b/gateway/gateway/endpoint/endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/config"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/graphql"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/queryvalidation"
+	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/requestparser"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/resolver"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/schema"
 	utilscontext "github.com/platform-mesh/kubernetes-graphql-gateway/gateway/utils/context"
@@ -22,12 +23,11 @@ import (
 
 // Endpoint combines a cluster connection with its GraphQL handler.
 type Endpoint struct {
-	name           string
-	cluster        *cluster.Cluster
-	graphqlServer  *graphql.GraphQLServer
-	handler        http.Handler
-	tokenValidator authn.Validator
-	cancelFunc     context.CancelFunc
+	name          string
+	cluster       *cluster.Cluster
+	graphqlServer *graphql.GraphQLServer
+	handler       http.Handler
+	cancelFunc    context.CancelFunc
 }
 
 func New(
@@ -64,11 +64,12 @@ func New(
 		return nil, fmt.Errorf("failed to create GraphQL schema: %w", err)
 	}
 
+	hasPathTemplate := schemaData.ClusterMetadata != nil && schemaData.ClusterMetadata.RequestPathTemplate != ""
+
 	graphqlServer := graphql.NewGraphQLServer(graphqlCfg)
 	gqlHandler := graphqlServer.CreateHandler(schemaProvider.GetSchema())
 
-	// The HTTP layer also checks Accept to route to separate timeout/concurrency pools.
-	handler := queryvalidation.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	gqlHTTPHandler := queryvalidation.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Accept") == "text/event-stream" {
 			graphqlServer.HandleSubscription(w, r, gqlHandler.Schema)
 			return
@@ -80,15 +81,43 @@ func New(
 		MaxBatchSize:  limits.MaxQueryBatchSize,
 	})
 
+	// Middleware chain (outermost runs first):
+	//   requestparser → clusterTarget extraction → auth → queryvalidation → graphql handler
+	handler := requestparser.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hasPathTemplate {
+			if reqs, ok := utilscontext.GetParsedRequestsFromCtx(r.Context()); ok {
+				if target := utilscontext.FindClusterTarget(reqs); target != "" {
+					r = r.WithContext(utilscontext.SetClusterTarget(r.Context(), target))
+				}
+			}
+		}
+
+		token, ok := utilscontext.GetTokenFromCtx(r.Context())
+		if !ok || token == "" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		authenticated, err := validator.Validate(r.Context(), token)
+		if err != nil {
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if !authenticated {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		gqlHTTPHandler.ServeHTTP(w, r)
+	}))
 	log.FromContext(ctx).Info("Registered endpoint", "cluster", name)
 
 	return &Endpoint{
-		name:           name,
-		cluster:        cl,
-		graphqlServer:  graphqlServer,
-		handler:        handler,
-		tokenValidator: validator,
-		cancelFunc:     validatorCancel,
+		name:          name,
+		cluster:       cl,
+		graphqlServer: graphqlServer,
+		handler:       handler,
+		cancelFunc:    validatorCancel,
 	}, nil
 }
 
@@ -97,23 +126,6 @@ func (e *Endpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Endpoint not ready", http.StatusServiceUnavailable)
 		return
 	}
-
-	token, ok := utilscontext.GetTokenFromCtx(r.Context())
-	if !ok || token == "" {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return
-	}
-
-	authenticated, err := e.tokenValidator.Validate(r.Context(), token)
-	if err != nil {
-		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
-		return
-	}
-	if !authenticated {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return
-	}
-
 	e.handler.ServeHTTP(w, r)
 }
 

--- a/gateway/gateway/queryvalidation/middleware.go
+++ b/gateway/gateway/queryvalidation/middleware.go
@@ -1,38 +1,39 @@
 package queryvalidation
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+
+	utilscontext "github.com/platform-mesh/kubernetes-graphql-gateway/gateway/utils/context"
 )
 
 // Middleware returns an http.Handler that validates incoming GraphQL queries
 // against depth and complexity limits before forwarding to the next handler.
 // Supports both single requests and batched query arrays.
 // If all limits are zero, the middleware is a no-op passthrough.
+//
+// Expects the request parser middleware to have stored parsed requests in context.
 func Middleware(next http.Handler, cfg Config) http.Handler {
 	if cfg.MaxDepth <= 0 && cfg.MaxComplexity <= 0 && cfg.MaxBatchSize <= 0 {
 		return next
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Body == nil || r.Method == http.MethodGet {
+		reqs, ok := utilscontext.GetParsedRequestsFromCtx(r.Context())
+		if !ok {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			writeGraphQLError(w, "failed to read request body", http.StatusBadRequest)
-			return
+		var queries []string
+		for _, req := range reqs {
+			if req.Query != "" {
+				queries = append(queries, req.Query)
+			}
 		}
-		r.Body = io.NopCloser(bytes.NewReader(body))
 
-		queries := extractQueries(body)
 		if len(queries) == 0 {
-			// Not valid JSON or no query field — let the GraphQL handler deal with it
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -51,33 +52,6 @@ func Middleware(next http.Handler, cfg Config) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
-}
-
-type graphqlRequest struct {
-	Query string `json:"query"`
-}
-
-// extractQueries extracts query strings from a GraphQL request body.
-// Supports both single requests {"query":"..."} and batched requests [{"query":"..."}, ...].
-// Returns the queries and true if extraction succeeded, or nil and false if the body
-// is not valid JSON or contains no queries.
-func extractQueries(body []byte) []string {
-	var reqs []graphqlRequest
-	if err := json.Unmarshal(body, &reqs); err != nil {
-		var req graphqlRequest
-		if err := json.Unmarshal(body, &req); err != nil {
-			return nil
-		}
-		reqs = []graphqlRequest{req}
-	}
-
-	queries := make([]string, 0, len(reqs))
-	for _, req := range reqs {
-		if req.Query != "" {
-			queries = append(queries, req.Query)
-		}
-	}
-	return queries
 }
 
 func writeGraphQLError(w http.ResponseWriter, message string, statusCode int) {

--- a/gateway/gateway/queryvalidation/middleware_test.go
+++ b/gateway/gateway/queryvalidation/middleware_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	utilscontext "github.com/platform-mesh/kubernetes-graphql-gateway/gateway/utils/context"
 )
 
 func TestMiddleware(t *testing.T) {
@@ -76,7 +78,7 @@ func TestMiddleware(t *testing.T) {
 			wantPass:   true,
 		},
 		{
-			name:       "non-JSON body passes through to graphql handler",
+			name:       "no parsed requests passes through",
 			cfg:        Config{MaxDepth: 1},
 			body:       `not json`,
 			method:     http.MethodPost,
@@ -164,6 +166,13 @@ func TestMiddleware(t *testing.T) {
 			if tt.method == http.MethodPost {
 				req.Header.Set("Content-Type", "application/json")
 			}
+
+			// Simulate the request parser middleware by setting parsed requests in context.
+			if reqs := parseBodies(tt.body); len(reqs) > 0 {
+				ctx := utilscontext.SetParsedRequests(req.Context(), reqs)
+				req = req.WithContext(ctx)
+			}
+
 			rec := httptest.NewRecorder()
 
 			handler.ServeHTTP(rec, req)
@@ -190,4 +199,20 @@ func TestMiddleware(t *testing.T) {
 			}
 		})
 	}
+}
+
+// parseBodies simulates what the request parser middleware does: parse JSON into GraphQLRequests.
+func parseBodies(body string) []utilscontext.GraphQLRequest {
+	if body == "" {
+		return nil
+	}
+	var reqs []utilscontext.GraphQLRequest
+	if err := json.Unmarshal([]byte(body), &reqs); err == nil {
+		return reqs
+	}
+	var req utilscontext.GraphQLRequest
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		return nil
+	}
+	return []utilscontext.GraphQLRequest{req}
 }

--- a/gateway/gateway/queryvalidation/queryvalidation_test.go
+++ b/gateway/gateway/queryvalidation/queryvalidation_test.go
@@ -7,57 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExtractQueries(t *testing.T) {
-	tests := []struct {
-		name      string
-		body      string
-		wantCount int
-	}{
-		{
-			name:      "single request",
-			body:      `{"query":"{ pods { name } }"}`,
-			wantCount: 1,
-		},
-		{
-			name:      "batched request",
-			body:      `[{"query":"{ a }"},{"query":"{ b }"}]`,
-			wantCount: 2,
-		},
-		{
-			name:      "batched request with empty queries filtered",
-			body:      `[{"query":"{ a }"},{"query":""},{"query":"{ b }"}]`,
-			wantCount: 2,
-		},
-		{
-			name: "empty single query",
-			body: `{"query":""}`,
-		},
-		{
-			name: "empty array",
-			body: `[]`,
-		},
-		{
-			name: "array with only empty queries",
-			body: `[{"query":""},{"query":""}]`,
-		},
-		{
-			name: "invalid JSON",
-			body: `not json`,
-		},
-		{
-			name: "empty body",
-			body: ``,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			queries := extractQueries([]byte(tt.body))
-			assert.Len(t, queries, tt.wantCount)
-		})
-	}
-}
-
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/gateway/gateway/requestparser/requestparser.go
+++ b/gateway/gateway/requestparser/requestparser.go
@@ -1,0 +1,50 @@
+package requestparser
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	utilscontext "github.com/platform-mesh/kubernetes-graphql-gateway/gateway/utils/context"
+)
+
+// Middleware reads the GraphQL request body, parses it into
+// []utilscontext.GraphQLRequest, and stores the result in the request context.
+// Downstream middlewares can call utilscontext.GetParsedRequestsFromCtx
+// instead of re-parsing the body.
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body == nil || r.Method == http.MethodGet {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewReader(body))
+
+		if reqs := parseRequests(body); len(reqs) > 0 {
+			ctx := utilscontext.SetParsedRequests(r.Context(), reqs)
+			r = r.WithContext(ctx)
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func parseRequests(body []byte) []utilscontext.GraphQLRequest {
+	var reqs []utilscontext.GraphQLRequest
+	if err := json.Unmarshal(body, &reqs); err == nil {
+		return reqs
+	}
+
+	var req utilscontext.GraphQLRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil
+	}
+	return []utilscontext.GraphQLRequest{req}
+}

--- a/gateway/gateway/requestparser/requestparser_test.go
+++ b/gateway/gateway/requestparser/requestparser_test.go
@@ -1,0 +1,138 @@
+package requestparser
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	utilscontext "github.com/platform-mesh/kubernetes-graphql-gateway/gateway/utils/context"
+)
+
+func TestMiddleware(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		body           string
+		expectParsed   bool
+		expectedCount  int
+		expectedQuery  string
+		expectedExtKey string
+	}{
+		{
+			name:          "single request",
+			method:        http.MethodPost,
+			body:          `{"query":"{ pods { name } }"}`,
+			expectParsed:  true,
+			expectedCount: 1,
+			expectedQuery: "{ pods { name } }",
+		},
+		{
+			name:          "single request with extensions",
+			method:        http.MethodPost,
+			body:          `{"query":"{ pods }","extensions":{"clusterTarget":"abc"}}`,
+			expectParsed:  true,
+			expectedCount: 1,
+			expectedQuery: "{ pods }",
+			expectedExtKey: "clusterTarget",
+		},
+		{
+			name:          "batched request",
+			method:        http.MethodPost,
+			body:          `[{"query":"{ pods }"},{"query":"{ nodes }"}]`,
+			expectParsed:  true,
+			expectedCount: 2,
+			expectedQuery: "{ pods }",
+		},
+		{
+			name:         "GET request skips parsing",
+			method:       http.MethodGet,
+			body:         "",
+			expectParsed: false,
+		},
+		{
+			name:         "invalid JSON",
+			method:       http.MethodPost,
+			body:         `not json`,
+			expectParsed: false,
+		},
+		{
+			name:         "empty body",
+			method:       http.MethodPost,
+			body:         "",
+			expectParsed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedReqs []utilscontext.GraphQLRequest
+			var found bool
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedReqs, found = utilscontext.GetParsedRequestsFromCtx(r.Context())
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := Middleware(next)
+
+			var body io.Reader
+			if tt.body != "" {
+				body = bytes.NewBufferString(tt.body)
+			}
+			req := httptest.NewRequest(tt.method, "/graphql", body)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if tt.expectParsed {
+				if !found {
+					t.Fatal("expected parsed requests in context, but none found")
+				}
+				if len(capturedReqs) != tt.expectedCount {
+					t.Fatalf("expected %d requests, got %d", tt.expectedCount, len(capturedReqs))
+				}
+				if capturedReqs[0].Query != tt.expectedQuery {
+					t.Errorf("expected query %q, got %q", tt.expectedQuery, capturedReqs[0].Query)
+				}
+				if tt.expectedExtKey != "" {
+					if capturedReqs[0].Extensions == nil {
+						t.Fatal("expected extensions, got nil")
+					}
+					if _, ok := capturedReqs[0].Extensions[tt.expectedExtKey]; !ok {
+						t.Errorf("expected extension key %q not found", tt.expectedExtKey)
+					}
+				}
+			} else {
+				if found {
+					t.Errorf("expected no parsed requests, but found %d", len(capturedReqs))
+				}
+			}
+		})
+	}
+}
+
+func TestMiddleware_RestoresBody(t *testing.T) {
+	originalBody := `{"query":"{ pods { name } }","extensions":{"clusterTarget":"abc123"}}`
+
+	var capturedBody string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read body in next handler: %v", err)
+		}
+		capturedBody = string(data)
+	})
+
+	handler := Middleware(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewBufferString(originalBody))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if capturedBody != originalBody {
+		t.Errorf("body was not restored: expected %q, got %q", originalBody, capturedBody)
+	}
+}

--- a/gateway/gateway/roundtripper/discovery.go
+++ b/gateway/gateway/roundtripper/discovery.go
@@ -42,10 +42,14 @@ func isDiscoveryRequest(req *http.Request) bool {
 	}
 	parts := strings.Split(path, "/")
 
-	if len(parts) >= 5 && parts[0] == "services" && parts[2] == "clusters" {
-		parts = parts[4:]
-	} else if len(parts) >= 3 && parts[0] == "clusters" {
-		parts = parts[2:]
+	// Strip any path prefix before the Kubernetes API segments.
+	// This handles KCP paths (/services/ws/clusters/cl/..., /clusters/cl/...),
+	// custom virtual workspace paths, or any other prefix-based multiplexing.
+	for i, part := range parts {
+		if part == "api" || part == "apis" || part == "openapi" {
+			parts = parts[i:]
+			break
+		}
 	}
 
 	switch {
@@ -56,6 +60,8 @@ func isDiscoveryRequest(req *http.Request) bool {
 	case len(parts) == 2 && parts[0] == "api":
 		return true
 	case len(parts) == 3 && parts[0] == "apis":
+		return true
+	case len(parts) >= 1 && parts[0] == "openapi":
 		return true
 	default:
 		return false

--- a/gateway/gateway/roundtripper/discovery.go
+++ b/gateway/gateway/roundtripper/discovery.go
@@ -43,10 +43,10 @@ func isDiscoveryRequest(req *http.Request) bool {
 	parts := strings.Split(path, "/")
 
 	// Strip any path prefix before the Kubernetes API segments.
-	// This handles KCP paths (/services/ws/clusters/cl/..., /clusters/cl/...),
-	// custom virtual workspace paths, or any other prefix-based multiplexing.
-	for i, part := range parts {
-		if part == "api" || part == "apis" || part == "openapi" {
+	// Scan from the end so that a prefix segment literally named "api" or "apis"
+	// (e.g. /services/api/clusters/cl/api/v1) doesn't shadow the real K8s root.
+	for i := len(parts) - 1; i >= 0; i-- {
+		if parts[i] == "api" || parts[i] == "apis" || parts[i] == "openapi" {
 			parts = parts[i:]
 			break
 		}

--- a/gateway/gateway/roundtripper/discovery_test.go
+++ b/gateway/gateway/roundtripper/discovery_test.go
@@ -40,6 +40,11 @@ func TestIsDiscoveryRequest(t *testing.T) {
 		{name: "openapi v3", method: http.MethodGet, path: "/openapi/v3", expected: true},
 		{name: "openapi with prefix", method: http.MethodGet, path: "/services/ws/clusters/cl/openapi/v2", expected: true},
 
+		// Prefix contains literal "api" segment — must not shadow the real K8s root
+		{name: "prefix api segment discovery", method: http.MethodGet, path: "/services/api/clusters/cl/api/v1", expected: true},
+		{name: "prefix api segment resource", method: http.MethodGet, path: "/services/api/clusters/cl/api/v1/pods", expected: false},
+		{name: "prefix apis segment discovery", method: http.MethodGet, path: "/prefix/apis/proxy/apis/apps", expected: true},
+
 		// Non-discovery requests
 		{name: "resource path", method: http.MethodGet, path: "/api/v1/namespaces", expected: false},
 		{name: "resource list", method: http.MethodGet, path: "/api/v1/pods", expected: false},

--- a/gateway/gateway/roundtripper/discovery_test.go
+++ b/gateway/gateway/roundtripper/discovery_test.go
@@ -1,0 +1,62 @@
+package roundtripper
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestIsDiscoveryRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		expected bool
+	}{
+		// Plain Kubernetes API paths
+		{name: "api root", method: http.MethodGet, path: "/api", expected: true},
+		{name: "apis root", method: http.MethodGet, path: "/apis", expected: true},
+		{name: "api version", method: http.MethodGet, path: "/api/v1", expected: true},
+		{name: "api group", method: http.MethodGet, path: "/apis/apps", expected: true},
+		{name: "api group version", method: http.MethodGet, path: "/apis/apps/v1", expected: true},
+
+		// KCP paths: /services/{ws}/clusters/{cl}/...
+		{name: "kcp services api", method: http.MethodGet, path: "/services/ws/clusters/cl/api", expected: true},
+		{name: "kcp services api version", method: http.MethodGet, path: "/services/ws/clusters/cl/api/v1", expected: true},
+		{name: "kcp services apis group", method: http.MethodGet, path: "/services/ws/clusters/cl/apis/apps", expected: true},
+		{name: "kcp services apis group version", method: http.MethodGet, path: "/services/ws/clusters/cl/apis/apps/v1", expected: true},
+
+		// KCP paths: /clusters/{cl}/...
+		{name: "kcp clusters api", method: http.MethodGet, path: "/clusters/cl/api", expected: true},
+		{name: "kcp clusters api version", method: http.MethodGet, path: "/clusters/cl/api/v1", expected: true},
+		{name: "kcp clusters apis group", method: http.MethodGet, path: "/clusters/cl/apis/apps", expected: true},
+
+		// Custom virtual workspace paths
+		{name: "custom vw prefix api", method: http.MethodGet, path: "/tenants/t1/proxy/api", expected: true},
+		{name: "custom vw prefix apis", method: http.MethodGet, path: "/tenants/t1/proxy/apis/apps/v1", expected: true},
+		{name: "deep prefix api", method: http.MethodGet, path: "/a/b/c/d/api/v1", expected: true},
+
+		// OpenAPI discovery
+		{name: "openapi v2", method: http.MethodGet, path: "/openapi/v2", expected: true},
+		{name: "openapi v3", method: http.MethodGet, path: "/openapi/v3", expected: true},
+		{name: "openapi with prefix", method: http.MethodGet, path: "/services/ws/clusters/cl/openapi/v2", expected: true},
+
+		// Non-discovery requests
+		{name: "resource path", method: http.MethodGet, path: "/api/v1/namespaces", expected: false},
+		{name: "resource list", method: http.MethodGet, path: "/api/v1/pods", expected: false},
+		{name: "custom resource", method: http.MethodGet, path: "/apis/apps/v1/deployments", expected: false},
+		{name: "post method", method: http.MethodPost, path: "/api", expected: false},
+		{name: "empty path", method: http.MethodGet, path: "/", expected: false},
+		{name: "non-api path", method: http.MethodGet, path: "/healthz", expected: false},
+		{name: "metrics path", method: http.MethodGet, path: "/metrics", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tt.method, "https://example.com"+tt.path, nil)
+			got := isDiscoveryRequest(req)
+			if got != tt.expected {
+				t.Errorf("isDiscoveryRequest(%s %s) = %v, want %v", tt.method, tt.path, got, tt.expected)
+			}
+		})
+	}
+}

--- a/gateway/gateway/roundtripper/pathtemplate.go
+++ b/gateway/gateway/roundtripper/pathtemplate.go
@@ -1,0 +1,35 @@
+package roundtripper
+
+import (
+	"net/http"
+	"strings"
+
+	utilscontext "github.com/platform-mesh/kubernetes-graphql-gateway/gateway/utils/context"
+)
+
+type PathTemplateHandler struct {
+	inner    http.RoundTripper
+	prefix   string
+	basePath string
+}
+
+func NewPathTemplateHandler(inner http.RoundTripper, prefix, basePath string) *PathTemplateHandler {
+	return &PathTemplateHandler{inner: inner, prefix: prefix, basePath: basePath}
+}
+
+func (h *PathTemplateHandler) RoundTrip(req *http.Request) (*http.Response, error) {
+	if h.prefix == "" {
+		return h.inner.RoundTrip(req)
+	}
+
+	target, ok := utilscontext.GetClusterTargetFromCtx(req.Context())
+	if !ok || target == "" {
+		return h.inner.RoundTrip(req)
+	}
+
+	resolved := strings.ReplaceAll(h.prefix, "{clusterTarget}", target)
+	newReq := req.Clone(req.Context())
+	newReq.URL.Path = resolved + strings.TrimPrefix(req.URL.Path, h.basePath)
+
+	return h.inner.RoundTrip(newReq)
+}

--- a/gateway/gateway/roundtripper/pathtemplate_test.go
+++ b/gateway/gateway/roundtripper/pathtemplate_test.go
@@ -1,0 +1,133 @@
+package roundtripper
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	utilscontext "github.com/platform-mesh/kubernetes-graphql-gateway/gateway/utils/context"
+)
+
+func TestPathTemplateHandler_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name           string
+		prefix         string
+		basePath       string
+		clusterTarget  string
+		requestPath    string
+		expectedPath   string
+		expectPassthru bool
+	}{
+		{
+			name:          "prefix includes base path",
+			prefix:        "/services/marketplace/clusters/{clusterTarget}",
+			basePath:      "/services/marketplace",
+			clusterTarget: "abc123",
+			requestPath:   "/services/marketplace/api/v1/pods",
+			expectedPath:  "/services/marketplace/clusters/abc123/api/v1/pods",
+		},
+		{
+			name:          "prefix without base path",
+			prefix:        "/clusters/{clusterTarget}",
+			basePath:      "/services/marketplace",
+			clusterTarget: "abc123",
+			requestPath:   "/services/marketplace/api/v1/pods",
+			expectedPath:  "/clusters/abc123/api/v1/pods",
+		},
+		{
+			name:          "custom prefix with base path",
+			prefix:        "/base/tenants/{clusterTarget}/proxy",
+			basePath:      "/base",
+			clusterTarget: "tenant-1",
+			requestPath:   "/base/apis/apps/v1/deployments",
+			expectedPath:  "/base/tenants/tenant-1/proxy/apis/apps/v1/deployments",
+		},
+		{
+			name:          "empty base path prepends prefix",
+			prefix:        "/clusters/{clusterTarget}",
+			basePath:      "",
+			clusterTarget: "abc123",
+			requestPath:   "/api/v1/pods",
+			expectedPath:  "/clusters/abc123/api/v1/pods",
+		},
+		{
+			name:           "empty prefix passes through",
+			prefix:         "",
+			clusterTarget:  "abc123",
+			requestPath:    "/api/v1/pods",
+			expectedPath:   "/api/v1/pods",
+			expectPassthru: true,
+		},
+		{
+			name:           "missing cluster target passes through",
+			prefix:         "/clusters/{clusterTarget}",
+			clusterTarget:  "",
+			requestPath:    "/api/v1/pods",
+			expectedPath:   "/api/v1/pods",
+			expectPassthru: true,
+		},
+		{
+			name:           "no cluster target in context passes through",
+			prefix:         "/clusters/{clusterTarget}",
+			requestPath:    "/api/v1/pods",
+			expectedPath:   "/api/v1/pods",
+			expectPassthru: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedPath string
+			inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				capturedPath = req.URL.Path
+				return &http.Response{StatusCode: http.StatusOK}, nil
+			})
+
+			handler := NewPathTemplateHandler(inner, tt.prefix, tt.basePath)
+
+			ctx := context.Background()
+			if tt.clusterTarget != "" {
+				ctx = utilscontext.SetClusterTarget(ctx, tt.clusterTarget)
+			}
+
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com"+tt.requestPath, nil)
+			_, err := handler.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if capturedPath != tt.expectedPath {
+				t.Errorf("expected path %q, got %q", tt.expectedPath, capturedPath)
+			}
+		})
+	}
+}
+
+func TestPathTemplateHandler_DoesNotMutateOriginalRequest(t *testing.T) {
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	})
+
+	handler := NewPathTemplateHandler(inner, "/clusters/{clusterTarget}", "")
+
+	ctx := utilscontext.SetClusterTarget(context.Background(), "abc123")
+	originalURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/api/v1/pods"}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, originalURL.String(), nil)
+
+	originalPath := req.URL.Path
+	_, err := handler.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if req.URL.Path != originalPath {
+		t.Errorf("original request URL was mutated: expected %q, got %q", originalPath, req.URL.Path)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/gateway/utils/context/cluster.go
+++ b/gateway/utils/context/cluster.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"regexp"
 )
 
 // contextKey is a custom type for context keys to avoid collisions
@@ -12,6 +13,14 @@ const clusterKey contextKey = "cluster-key"
 
 // tokenKey is the context key for storing authentication token
 const tokenKey contextKey = "token-key"
+
+// clusterTargetKey is the context key for storing the logical cluster target
+// extracted from GraphQL extensions.
+const clusterTargetKey contextKey = "cluster-target-key"
+
+// parsedRequestsKey is the context key for the pre-parsed GraphQL request body.
+// Set once by the request parser middleware; consumed by downstream middlewares.
+const parsedRequestsKey contextKey = "parsed-requests-key"
 
 // SetCluster sets cluster to the request context
 func SetCluster(ctx context.Context, cluster string) context.Context {
@@ -35,4 +44,48 @@ func GetClusterFromCtx(ctx context.Context) (string, bool) {
 func GetTokenFromCtx(ctx context.Context) (string, bool) {
 	v, ok := ctx.Value(tokenKey).(string)
 	return v, ok
+}
+
+// SetClusterTarget sets the logical cluster target in the request context.
+func SetClusterTarget(ctx context.Context, target string) context.Context {
+	return context.WithValue(ctx, clusterTargetKey, target)
+}
+
+// GetClusterTargetFromCtx retrieves the logical cluster target from the request context.
+// Returns the target and true if found, or empty string and false otherwise.
+func GetClusterTargetFromCtx(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(clusterTargetKey).(string)
+	return v, ok
+}
+
+// GraphQLRequest holds a single parsed GraphQL request from the body.
+// Shared across middlewares so the body is only parsed once.
+type GraphQLRequest struct {
+	Query      string         `json:"query"`
+	Extensions map[string]any `json:"extensions,omitempty"`
+}
+
+// SetParsedRequests stores the pre-parsed GraphQL requests in the context.
+func SetParsedRequests(ctx context.Context, reqs []GraphQLRequest) context.Context {
+	return context.WithValue(ctx, parsedRequestsKey, reqs)
+}
+
+// GetParsedRequestsFromCtx retrieves the pre-parsed GraphQL requests from the context.
+func GetParsedRequestsFromCtx(ctx context.Context) ([]GraphQLRequest, bool) {
+	v, ok := ctx.Value(parsedRequestsKey).([]GraphQLRequest)
+	return v, ok
+}
+
+var validClusterTarget = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9:_-]*$`)
+
+func FindClusterTarget(reqs []GraphQLRequest) string {
+	for _, req := range reqs {
+		if req.Extensions == nil {
+			continue
+		}
+		if v, ok := req.Extensions["clusterTarget"].(string); ok && validClusterTarget.MatchString(v) {
+			return v
+		}
+	}
+	return ""
 }

--- a/gateway/utils/context/cluster.go
+++ b/gateway/utils/context/cluster.go
@@ -78,12 +78,14 @@ func GetParsedRequestsFromCtx(ctx context.Context) ([]GraphQLRequest, bool) {
 
 var validClusterTarget = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9:_-]*$`)
 
+const maxClusterTargetLen = 2048
+
 func FindClusterTarget(reqs []GraphQLRequest) string {
 	for _, req := range reqs {
 		if req.Extensions == nil {
 			continue
 		}
-		if v, ok := req.Extensions["clusterTarget"].(string); ok && validClusterTarget.MatchString(v) {
+		if v, ok := req.Extensions["clusterTarget"].(string); ok && len(v) <= maxClusterTargetLen && validClusterTarget.MatchString(v) {
 			return v
 		}
 	}

--- a/listener/controllers/clusteraccess/clusteraccess_controller.go
+++ b/listener/controllers/clusteraccess/clusteraccess_controller.go
@@ -241,6 +241,10 @@ func buildTargetClusterConfig(ctx context.Context, clusterAccess v1alpha1.Cluste
 		config.Host = spec.Host
 	}
 
+	if spec.IntrospectionPath != "" {
+		config.Host += spec.IntrospectionPath
+	}
+
 	return config, nil
 }
 


### PR DESCRIPTION
- Added `IntrospectionPath` and `RequestPathTemplate` fields to `ClusterAccessSpec` for better API discovery and request handling.
- Updated `ClusterMetadata` to include the new fields, ensuring they are populated from `ClusterAccess`.
- Modified the CRD and API resource schema to reflect the new fields and their descriptions.
- Implemented middleware for request parsing, allowing downstream handlers to access parsed GraphQL requests.
- Enhanced the roundtripper to support path templates, enabling dynamic request routing based on cluster targets.
- Updated tests to cover new functionality and ensure existing behavior remains intact.