### PR TITLE
feat: add GRPCMaxRecvMsgSize and GRPCMaxSendMsgSize options for gRPC message size configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Optionally set `ca.secretRef` for custom CA certificates.
 | `--schemas-dir` | `_output/schemas` | Directory to watch for schema files |
 | `--schema-handler` | `file` | How to receive schema updates: `file` or `grpc` |
 | `--grpc-listener-address` | `localhost:50051` | gRPC listener address (when `--schema-handler=grpc`) |
+| `--grpc-max-recv-msg-size` | `4194304` (4 MB) | Max gRPC receive message size in bytes (when `--schema-handler=grpc`) |
 | `--gateway-port` | `8080` | Port for the GraphQL server |
 | `--gateway-address` | `0.0.0.0` | Bind address for the GraphQL server |
 | `--enable-playground` | `false` | Enable the GraphQL playground UI |
@@ -217,6 +218,7 @@ Set any limit flag to `0` to disable that limit.
 | `--schemas-dir` | `_output/schemas` | Directory to store generated schema files |
 | `--schema-handler` | `file` | Schema transport: `file` or `grpc` |
 | `--grpc-listen-addr` | `:50051` | gRPC server address (when `--schema-handler=grpc`) |
+| `--grpc-max-send-msg-size` | `4194304` (4 MB) | Max gRPC send message size in bytes (when `--schema-handler=grpc`) |
 | `--reconciler-gvr` | `namespaces.v1` | GroupVersionResource the reconciler watches |
 | `--anchor-resource` | `object.metadata.name == 'default'` | CEL expression to match the anchor resource |
 | `--enable-clusteraccess-controller` | `false` | Enable the ClusterAccess CRD controller |

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -1,0 +1,3 @@
+package defaults
+
+const DefaultGRPCMaxMsgSize = 4 * 1024 * 1024 // 4MB

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -22,9 +22,10 @@ func NewConfig(opts *options.CompletedOptions) (*Config, error) {
 	}
 
 	gatewayServer, err := gateway.New(gatewayconfig.Gateway{
-		SchemaHandler:   cfg.Options.SchemaHandler,
-		SchemaDirectory: cfg.Options.SchemasDir,
-		GRPCAddress:     cfg.Options.GRPCListenerAddress,
+		SchemaHandler:      cfg.Options.SchemaHandler,
+		SchemaDirectory:    cfg.Options.SchemasDir,
+		GRPCAddress:        cfg.Options.GRPCListenerAddress,
+		GRPCMaxRecvMsgSize: cfg.Options.GRPCMaxRecvMsgSize,
 		GraphQL: gatewayconfig.GraphQL{
 			Pretty:     true,
 			Playground: cfg.Options.PlaygroundEnabled,

--- a/gateway/gateway/config/config.go
+++ b/gateway/gateway/config/config.go
@@ -13,6 +13,9 @@ type Gateway struct {
 	// GRPCAddress is the gRPC server address when SchemaHandler is "grpc"
 	GRPCAddress string
 
+	// GRPCMaxRecvMsgSize is the maximum gRPC message size in bytes the gateway will accept.
+	GRPCMaxRecvMsgSize int
+
 	// GraphQL contains GraphQL-specific configuration
 	GraphQL GraphQL
 

--- a/gateway/gateway/server.go
+++ b/gateway/gateway/server.go
@@ -52,7 +52,10 @@ func (s *Service) Run(ctx context.Context) error {
 	case "grpc":
 		logger.Info("Starting gRPC watcher", "address", s.config.GRPCAddress)
 		gw, err := watcher.NewGRPCWatcher(
-			watcher.GRPCWatcherConfig{Address: s.config.GRPCAddress},
+			watcher.GRPCWatcherConfig{
+				Address:        s.config.GRPCAddress,
+				MaxRecvMsgSize: s.config.GRPCMaxRecvMsgSize,
+			},
 			s.registry,
 			&s.connected,
 		)
@@ -132,4 +135,3 @@ func (s *Service) IsReady(_ *http.Request) error {
 	}
 	return nil
 }
-

--- a/gateway/gateway/watcher/grpc.go
+++ b/gateway/gateway/watcher/grpc.go
@@ -29,6 +29,8 @@ type GRPCWatcher struct {
 type GRPCWatcherConfig struct {
 	// Address is the gRPC server address (e.g., "localhost:50051")
 	Address string
+	// MaxRecvMsgSize is the maximum message size in bytes the client can receive.
+	MaxRecvMsgSize int
 }
 
 // NewGRPCWatcher creates a new gRPC watcher that connects to the given address
@@ -38,6 +40,7 @@ func NewGRPCWatcher(config GRPCWatcherConfig, handler SchemaEventHandler, connec
 	conn, err := grpc.NewClient(
 		config.Address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(config.MaxRecvMsgSize)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to gRPC server: %w", err)

--- a/gateway/gateway/watcher/grpc_test.go
+++ b/gateway/gateway/watcher/grpc_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/platform-mesh/kubernetes-graphql-gateway/defaults"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/watcher"
 	proto "github.com/platform-mesh/kubernetes-graphql-gateway/sdk"
 	"github.com/stretchr/testify/assert"
@@ -57,7 +58,7 @@ func TestGRPCWatcher_ConnectsAndReceives(t *testing.T) {
 
 	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{
 		Address:        lis.Addr().String(),
-		MaxRecvMsgSize: 4 * 1024 * 1024,
+		MaxRecvMsgSize: defaults.DefaultGRPCMaxMsgSize,
 	}, handler, &connected)
 	require.NoError(t, err)
 

--- a/gateway/gateway/watcher/grpc_test.go
+++ b/gateway/gateway/watcher/grpc_test.go
@@ -55,7 +55,10 @@ func TestGRPCWatcher_ConnectsAndReceives(t *testing.T) {
 	handler := newFakeHandler()
 	var connected atomic.Bool
 
-	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{Address: lis.Addr().String()}, handler, &connected)
+	gw, err := watcher.NewGRPCWatcher(watcher.GRPCWatcherConfig{
+		Address:        lis.Addr().String(),
+		MaxRecvMsgSize: 4 * 1024 * 1024,
+	}, handler, &connected)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/gateway/options/options.go
+++ b/gateway/options/options.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/platform-mesh/kubernetes-graphql-gateway/defaults"
 	"github.com/spf13/pflag"
 
 	"k8s.io/component-base/logs"
@@ -83,7 +84,7 @@ func NewOptions() *Options {
 			SchemasDir:               "_output/schemas",
 			SchemaHandler:            "file",
 			GRPCListenerAddress:      "localhost:50051",
-			GRPCMaxRecvMsgSize:       4 * 1024 * 1024,
+			GRPCMaxRecvMsgSize:       defaults.DefaultGRPCMaxMsgSize,
 			ServerBindAddress:        "0.0.0.0",
 			ServerBindPort:           8080,
 			PlaygroundEnabled:        false,

--- a/gateway/options/options.go
+++ b/gateway/options/options.go
@@ -23,6 +23,8 @@ type ExtraOptions struct {
 	SchemaHandler string
 	// GRPCListenerAddress is the address of the gRPC listener (used with grpc watcher).
 	GRPCListenerAddress string
+	// GRPCMaxRecvMsgSize is the maximum gRPC message size in bytes the gateway will accept.
+	GRPCMaxRecvMsgSize int
 	// ServerBindAddress is the address for the GraphQL gateway server.
 	ServerBindAddress string
 	// ServerBindPort is the port for the GraphQL gateway server.
@@ -81,6 +83,7 @@ func NewOptions() *Options {
 			SchemasDir:               "_output/schemas",
 			SchemaHandler:            "file",
 			GRPCListenerAddress:      "localhost:50051",
+			GRPCMaxRecvMsgSize:       4 * 1024 * 1024,
 			ServerBindAddress:        "0.0.0.0",
 			ServerBindPort:           8080,
 			PlaygroundEnabled:        false,
@@ -109,6 +112,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&options.SchemasDir, "schemas-dir", options.SchemasDir, "directory to watch for schema files (used with --schema-handler=file)")
 	fs.StringVar(&options.SchemaHandler, "schema-handler", options.SchemaHandler, "how to receive schema updates: 'file' or 'grpc'")
 	fs.StringVar(&options.GRPCListenerAddress, "grpc-listener-address", options.GRPCListenerAddress, "address of the gRPC listener (used with --schema-handler=grpc)")
+	fs.IntVar(&options.GRPCMaxRecvMsgSize, "grpc-max-recv-msg-size", options.GRPCMaxRecvMsgSize, "maximum gRPC receive message size in bytes (used with --schema-handler=grpc)")
 	fs.IntVar(&options.ServerBindPort, "gateway-port", options.ServerBindPort, "port for the GraphQL gateway server")
 	fs.StringVar(&options.ServerBindAddress, "gateway-address", options.ServerBindAddress, "address for the GraphQL gateway server")
 	fs.BoolVar(&options.PlaygroundEnabled, "enable-playground", options.PlaygroundEnabled, "enable the GraphQL playground")
@@ -142,6 +146,10 @@ func (options *Options) Complete() (*CompletedOptions, error) {
 func (options *CompletedOptions) Validate() error {
 	if options.SchemaHandler == "grpc" && options.GRPCListenerAddress == "" {
 		return errors.New("--grpc-listener-address must be set when --schema-handler=grpc")
+	}
+
+	if options.SchemaHandler == "grpc" && options.GRPCMaxRecvMsgSize <= 0 {
+		return errors.New("--grpc-max-recv-msg-size must be a positive value")
 	}
 
 	if options.SchemaHandler == "file" && options.SchemasDir == "" {

--- a/listener/config.go
+++ b/listener/config.go
@@ -254,7 +254,7 @@ func NewConfig(options *options.CompletedOptions) (*Config, error) {
 
 		handler := schemahandler.NewGRPCHandler()
 
-		srv := grpc.NewServer()
+		srv := grpc.NewServer(grpc.MaxSendMsgSize(options.GRPCMaxSendMsgSize))
 		sdk.RegisterSchemaHandlerServer(srv, handler)
 		reflection.Register(srv)
 

--- a/listener/options/options.go
+++ b/listener/options/options.go
@@ -58,6 +58,8 @@ type ExtraOptions struct {
 	SchemaHandler string
 	// GRPCListenAddr is the gRPC server listener address (only used if SchemaHandler is "grpc")
 	GRPCListenAddr string
+	// GRPCMaxSendMsgSize is the maximum gRPC message size in bytes the server will send.
+	GRPCMaxSendMsgSize int
 
 	AdditonalPathAnnotationKey string
 
@@ -98,6 +100,7 @@ func NewOptions() *Options {
 			SchemaHandler:            "file",
 			SchemasDir:               "_output/schemas",
 			GRPCListenAddr:           ":50051",
+			GRPCMaxSendMsgSize:       4 * 1024 * 1024,
 			AnchorResource:           "object.metadata.name == 'default'",
 			ResourceGVR:              "namespaces.v1",
 			MetricsBindAddress:       "0",
@@ -133,6 +136,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&options.SchemaHandler, "schema-handler", options.SchemaHandler, "The type of schema handler to use (e.g., 'file', 'grpc')")
 	fs.StringVar(&options.SchemasDir, "schemas-dir", options.SchemasDir, "SchemasDir is the directory to store schema files. Only required if using file schema handler")
 	fs.StringVar(&options.GRPCListenAddr, "grpc-listen-addr", options.GRPCListenAddr, "The gRPC server listener address (only used if SchemaHandler is 'grpc')")
+	fs.IntVar(&options.GRPCMaxSendMsgSize, "grpc-max-send-msg-size", options.GRPCMaxSendMsgSize, "maximum gRPC send message size in bytes (used with --schema-handler=grpc)")
 
 	fs.StringVar(&options.AnchorResource, "anchor-resource", options.AnchorResource, "Resource to watch as anchor for kubernetes provider (default: default)")
 	fs.StringVar(&options.ResourceGVR, "reconciler-gvr", options.ResourceGVR, "The GroupVersionResource which the reconciler will be watching (default: namespaces.v1)")
@@ -224,6 +228,9 @@ func (options *CompletedOptions) Validate() error {
 	if options.SchemaHandler == "grpc" {
 		if options.GRPCListenAddr == "" {
 			return fmt.Errorf("grpc-listen-addr must be specified when schema-handler is 'grpc'")
+		}
+		if options.GRPCMaxSendMsgSize <= 0 {
+			return fmt.Errorf("--grpc-max-send-msg-size must be a positive value")
 		}
 	}
 

--- a/listener/options/options.go
+++ b/listener/options/options.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/platform-mesh/kubernetes-graphql-gateway/apis/v1alpha1"
+	"github.com/platform-mesh/kubernetes-graphql-gateway/defaults"
 	providerkcp "github.com/platform-mesh/kubernetes-graphql-gateway/providers/kcp/options"
 	"github.com/spf13/pflag"
 
@@ -100,7 +101,7 @@ func NewOptions() *Options {
 			SchemaHandler:            "file",
 			SchemasDir:               "_output/schemas",
 			GRPCListenAddr:           ":50051",
-			GRPCMaxSendMsgSize:       4 * 1024 * 1024,
+			GRPCMaxSendMsgSize:       defaults.DefaultGRPCMaxMsgSize,
 			AnchorResource:           "object.metadata.name == 'default'",
 			ResourceGVR:              "namespaces.v1",
 			MetricsBindAddress:       "0",


### PR DESCRIPTION
Add flags for the gateway and listener to be able to configure the sizes.

Add `--grpc-max-recv-msg-size` flag to the gateway binary to configure the maximum gRPC message size the client will accept
Add `--grpc-max-send-msg-size` flag to the listener binary to configure the maximum gRPC message size the server will send
Both default to 4 MB (matching the current gRPC library default), so this is a no-op change for existing deployments

Motivation
Large schema payloads cause the gRPC stream between listener and gateway to fail:

`gRPC stream error, reconnecting error: rpc error: code = ResourceExhausted
  desc = grpc: received message larger than max (11497764 vs. 4194304)`

The gRPC library default of 4 MB is too small for clusters with many CRDs. This change makes the limit configurable so operators can raise it as needed (e.g., --grpc-max-recv-msg-size=33554432 for 32 MB).

Refers to: https://github.com/platform-mesh/kubernetes-graphql-gateway/issues/216