### PR TITLE
fix: Add finalizer to prevent orphaned schema files on ClusterAccess deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The listener and gateway communicate via `--schema-handler`, which both componen
 **Terminal 1** — Start the listener:
 
 ```sh
-go run ./cmd/listener/listener.go --schema-handler grpc
+go run main.go listener --schema-handler grpc
 ```
 
 This starts the listener in `single` mode with a gRPC server on `:50051`. It watches namespaces on your local cluster and when it finds the `default` namespace (the anchor resource), generates and streams the GraphQL schema to connected gateways.
@@ -59,7 +59,7 @@ This starts the listener in `single` mode with a gRPC server on `:50051`. It wat
 **Terminal 2** — Start the gateway:
 
 ```sh
-go run ./cmd/gateway/gateway.go --schema-handler grpc --enable-playground
+go run main.go gateway --schema-handler grpc --enable-playground
 ```
 
 This starts the gateway on port `8080` with the GraphQL playground enabled. It connects to the listener's gRPC server and receives schemas, creating an endpoint at `/api/clusters/single/graphql`.
@@ -107,13 +107,13 @@ spec:
 3. Start the listener with the ClusterAccess controller enabled:
 
 ```sh
-go run ./cmd/listener/listener.go --schema-handler grpc --enable-clusteraccess-controller
+go run main.go listener --schema-handler grpc --enable-clusteraccess-controller
 ```
 
 4. Start the gateway:
 
 ```sh
-go run ./cmd/gateway/gateway.go --schema-handler grpc --enable-playground
+go run main.go gateway --schema-handler grpc --enable-playground
 ```
 
 5. Query at: `http://localhost:8080/api/clusters/my-cluster/graphql`

--- a/listener/controllers/clusteraccess/clusteraccess_controller.go
+++ b/listener/controllers/clusteraccess/clusteraccess_controller.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
@@ -31,7 +32,8 @@ import (
 )
 
 const (
-	controllerName = "clusteraccess-schema-controller"
+	controllerName         = "clusteraccess-schema-controller"
+	schemaCleanupFinalizer = "gateway.platform-mesh.io/schema-cleanup"
 
 	// ConditionTypeReady indicates whether the ClusterAccess schema was
 	// successfully generated and written.
@@ -86,9 +88,10 @@ func (r *ClusterAccessReconciler) Reconcile(ctx context.Context, req mcreconcile
 	ca := &v1alpha1.ClusterAccess{}
 	if err := c.Get(ctx, client.ObjectKey{Name: req.Name}, ca); err != nil {
 		if k8serrors.IsNotFound(err) {
+			// Fallback for resources that predate the finalizer: schema path equals the
+			// resource name (the case when spec.path was not set). Resources with a custom
+			// spec.path are cleaned up via the finalizer before the object disappears.
 			logger.Info("ClusterAccess resource not found, cleaning up schema", "name", req.Name)
-			// Delete the schema file if ClusterAccess is deleted
-			// Try both possible paths (resource name and path field)
 			name := req.Name
 			if clusterName != "" {
 				name = fmt.Sprintf("%s-%s", clusterName, name)
@@ -99,6 +102,31 @@ func (r *ClusterAccessReconciler) Reconcile(ctx context.Context, req mcreconcile
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get ClusterAccess: %w", err)
+	}
+
+	// Handle deletion: the finalizer keeps the object alive so we can read spec.path.
+	if !ca.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(ca, schemaCleanupFinalizer) {
+			schemaPath := resolveSchemaPath(ca, clusterName)
+			if err := r.ioHandler.Delete(ctx, schemaPath); err != nil {
+				logger.Error(err, "Failed to cleanup schema during deletion", "path", schemaPath)
+			}
+			patch := client.MergeFrom(ca.DeepCopy())
+			controllerutil.RemoveFinalizer(ca, schemaCleanupFinalizer)
+			if err := c.Patch(ctx, ca, patch); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure the cleanup finalizer is registered before doing any work.
+	if !controllerutil.ContainsFinalizer(ca, schemaCleanupFinalizer) {
+		patch := client.MergeFrom(ca.DeepCopy())
+		controllerutil.AddFinalizer(ca, schemaCleanupFinalizer)
+		if err := c.Patch(ctx, ca, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
 	}
 
 	result, reconcileErr := r.reconcileClusterAccess(ctx, ca, c, cl.GetConfig(), clusterName)
@@ -122,13 +150,7 @@ func (r *ClusterAccessReconciler) reconcileClusterAccess(
 	logger := log.FromContext(ctx)
 
 	// Determine cluster name/path for the schema file
-	clusterName := ca.GetName()
-	if ca.Spec.Path != "" {
-		clusterName = ca.Spec.Path
-	}
-	if reqClusterName != "" {
-		clusterName = fmt.Sprintf("%s-%s", reqClusterName, clusterName)
-	}
+	clusterName := resolveSchemaPath(ca, reqClusterName)
 
 	// Build target cluster config from ClusterAccess spec
 	targetConfig, err := buildTargetClusterConfig(ctx, *ca, c, currentConfig)
@@ -222,6 +244,19 @@ func (r *ClusterAccessReconciler) SetupWithManager(mgr mcmanager.Manager, forOpt
 		WithOptions(r.opts).
 		Named(controllerName).
 		Complete(r)
+}
+
+// resolveSchemaPath returns the schema file path for a ClusterAccess, derived from
+// spec.path (if set) or the resource name, optionally prefixed with the cluster name.
+func resolveSchemaPath(ca *v1alpha1.ClusterAccess, clusterName string) string {
+	name := ca.GetName()
+	if ca.Spec.Path != "" {
+		name = ca.Spec.Path
+	}
+	if clusterName != "" {
+		return fmt.Sprintf("%s-%s", clusterName, name)
+	}
+	return name
 }
 
 func buildTargetClusterConfig(ctx context.Context, clusterAccess v1alpha1.ClusterAccess, c client.Client, currentConfig *rest.Config) (*rest.Config, error) {

--- a/listener/controllers/clusteraccess/clusteraccess_controller_test.go
+++ b/listener/controllers/clusteraccess/clusteraccess_controller_test.go
@@ -197,6 +197,16 @@ func (suite *ClusterAccessControllerTestSuite) waitForSchemaFile(name string) {
 		"expected schema file to be generated for %s", name)
 }
 
+// waitForSchemaFileDeleted waits for a schema file to be removed
+func (suite *ClusterAccessControllerTestSuite) waitForSchemaFileDeleted(name string) {
+	schemaFilePath := filepath.Join(suite.listenerCfg.Options.SchemasDir, name)
+	suite.Eventually(func() bool {
+		_, err := os.Stat(schemaFilePath)
+		return os.IsNotExist(err)
+	}, 10*time.Second, 500*time.Millisecond,
+		"expected schema file to be deleted for %s", name)
+}
+
 // verifySchemaMetadata reads and validates the schema file
 func (suite *ClusterAccessControllerTestSuite) verifySchemaMetadata(
 	name string,
@@ -524,4 +534,47 @@ func (suite *ClusterAccessControllerTestSuite) TestServiceAccountAuth() {
 	suite.Equal("test-sa", metadata.Auth.SAName, "SA name should match")
 	suite.Equal(testNamespace, metadata.Auth.SANamespace, "SA namespace should match")
 	suite.NotEmpty(metadata.Auth.Token, "SA auth should have generated token")
+}
+
+// TestPathFieldCleanup verifies that deleting a ClusterAccess with a custom spec.path
+// removes the schema file at the path-derived location and not the resource-name location.
+func (suite *ClusterAccessControllerTestSuite) TestPathFieldCleanup() {
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "path-cleanup-secret",
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"kubeconfig": suite.envtestKubeconfig,
+		},
+	}
+	err := suite.client.Create(context.Background(), kubeconfigSecret)
+	suite.Require().NoError(err, "failed to create kubeconfig secret")
+
+	clusterAccess := &v1alpha1.ClusterAccess{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "path-cleanup-test",
+		},
+		Spec: v1alpha1.ClusterAccessSpec{
+			Path: "custom-path",
+			Auth: &v1alpha1.AuthConfig{
+				KubeconfigSecretRef: &v1alpha1.SecretKeyRef{
+					SecretReference: corev1.SecretReference{
+						Name:      "path-cleanup-secret",
+						Namespace: testNamespace,
+					},
+					Key: "kubeconfig",
+				},
+			},
+		},
+	}
+	err = suite.client.Create(context.Background(), clusterAccess)
+	suite.Require().NoError(err, "failed to create ClusterAccess")
+
+	suite.waitForSchemaFile("single-custom-path")
+
+	err = suite.client.Delete(context.Background(), clusterAccess)
+	suite.Require().NoError(err, "failed to delete ClusterAccess")
+
+	suite.waitForSchemaFileDeleted("single-custom-path")
 }


### PR DESCRIPTION
## Summary
- Deleting a ClusterAccess with a custom `spec.path` left an orphaned schema file because the object was already gone when cleanup ran, making `spec.path` inaccessible
- Adds a `gateway.platform-mesh.io/schema-cleanup` finalizer so the controller can read `spec.path` before the object is removed
- Extracts `resolveSchemaPath` helper to deduplicate path resolution between reconcile and deletion
- Retains the `NotFound` fallback for CRs that predate the finalizer

Refers to: https://github.com/platform-mesh/kubernetes-graphql-gateway/issues/219