### PR TITLE
fix: update naming conventions for generated type names to avoid collisions

### DIFF
--- a/gateway/schema/types/naming.go
+++ b/gateway/schema/types/naming.go
@@ -28,11 +28,13 @@ func SanitizeFieldName(name string) string {
 
 // GenerateTypeName creates a type name from a prefix and field path.
 // This is used to generate unique names for nested types.
-// Each path element is capitalized for readability (e.g., "PodSpecContainers").
+// Underscore separation ensures nested type names never collide with
+// top-level resource type names (which are PascalCase without underscores).
 func GenerateTypeName(typePrefix string, fieldPath []string) string {
 	var b strings.Builder
 	b.WriteString(typePrefix)
 	for _, field := range fieldPath {
+		b.WriteByte('_')
 		b.WriteString(capitalize(field))
 	}
 	return b.String()

--- a/gateway/schema/types/naming_test.go
+++ b/gateway/schema/types/naming_test.go
@@ -70,7 +70,7 @@ func TestGenerateTypeName(t *testing.T) {
 			name:       "simple_case",
 			typePrefix: "Pod",
 			fieldPath:  []string{"spec", "containers"},
-			expected:   "PodSpecContainers",
+			expected:   "Pod_Spec_Containers",
 		},
 		{
 			name:       "empty_field_path",
@@ -82,13 +82,13 @@ func TestGenerateTypeName(t *testing.T) {
 			name:       "single_field",
 			typePrefix: "ConfigMap",
 			fieldPath:  []string{"data"},
-			expected:   "ConfigMapData",
+			expected:   "ConfigMap_Data",
 		},
 		{
 			name:       "nested_path",
 			typePrefix: "Deployment",
 			fieldPath:  []string{"spec", "template", "spec", "containers"},
-			expected:   "DeploymentSpecTemplateSpecContainers",
+			expected:   "Deployment_Spec_Template_Spec_Containers",
 		},
 	}
 

--- a/gateway/schema/types/registry.go
+++ b/gateway/schema/types/registry.go
@@ -90,8 +90,17 @@ func (r *Registry) UnmarkProcessing(key string) {
 	}
 }
 
+// reservedTypeNames are names used by the GraphQL schema infrastructure
+// that resource types must not collide with.
+var reservedTypeNames = map[string]bool{
+	"Query":        true,
+	"Mutation":     true,
+	"Subscription": true,
+}
+
 // GetUniqueTypeName returns a unique type name for a GVK, handling conflicts
-// when the same Kind exists in different API groups.
+// when the same Kind exists in different API groups or collides with reserved
+// GraphQL root type names (Query, Mutation, Subscription).
 func (r *Registry) GetUniqueTypeName(gvk *schema.GroupVersionKind) string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -99,19 +108,27 @@ func (r *Registry) GetUniqueTypeName(gvk *schema.GroupVersionKind) string {
 	kind := gvk.Kind
 	groupVersion := gvk.GroupVersion().String()
 
+	if reservedTypeNames[kind] {
+		return prefixedTypeName(gvk)
+	}
+
 	if existingGroupVersion, exists := r.typeNameRegistry[kind]; exists {
 		if existingGroupVersion != groupVersion {
-			sanitizedGroup := ""
-			if gvk.Group != "" {
-				sanitizedGroup = SanitizeGroupName(gvk.Group)
-			}
-			return flect.Pascalize(sanitizedGroup+"_"+gvk.Version) + kind
+			return prefixedTypeName(gvk)
 		}
 	} else {
 		r.typeNameRegistry[kind] = groupVersion
 	}
 
 	return kind
+}
+
+func prefixedTypeName(gvk *schema.GroupVersionKind) string {
+	sanitizedGroup := ""
+	if gvk.Group != "" {
+		sanitizedGroup = SanitizeGroupName(gvk.Group)
+	}
+	return flect.Pascalize(sanitizedGroup+"_"+gvk.Version) + gvk.Kind
 }
 
 // SanitizeGroupName converts a Kubernetes API group name to a valid GraphQL identifier.

--- a/gateway/schema/types/registry_test.go
+++ b/gateway/schema/types/registry_test.go
@@ -139,6 +139,37 @@ func TestRegistry_GetUniqueTypeName_GroupWithDots(t *testing.T) {
 	assert.Equal(t, "ExtensionsV1beta1Ingress", registry.GetUniqueTypeName(&gvk2))
 }
 
+func TestRegistry_GetUniqueTypeName_ReservedNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		gvk      schema.GroupVersionKind
+		expected string
+	}{
+		{
+			name:     "Subscription kind is always prefixed",
+			gvk:      schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1", Kind: "Subscription"},
+			expected: "MessagingKnativeDevV1Subscription",
+		},
+		{
+			name:     "Query kind is always prefixed",
+			gvk:      schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Query"},
+			expected: "ExampleComV1Query",
+		},
+		{
+			name:     "Mutation kind is always prefixed",
+			gvk:      schema.GroupVersionKind{Group: "example.com", Version: "v1beta1", Kind: "Mutation"},
+			expected: "ExampleComV1beta1Mutation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := types.NewRegistry()
+			assert.Equal(t, tt.expected, registry.GetUniqueTypeName(&tt.gvk))
+		})
+	}
+}
+
 func TestRegistry_IsProcessing_AfterMark(t *testing.T) {
 	registry := types.NewRegistry()
 


### PR DESCRIPTION
Previously, nested types used a different casing convention (e.g., Componentstatus vs ComponentStatus) that avoided collisions. After field names started being capitalized consistently, the generated nested type names became identical to resource type names.

Use underscore separation for nested type names (e.g., Component_Status instead of ComponentStatus). This structurally prevents collisions since resource type names are always PascalCase without underscores. Additionally, reserve the GraphQL root type names (Query, Mutation, Subscription) so that CRDs with those Kinds are automatically prefixed with their group and version (e.g., MessagingKnativeDevV1Subscription).

Refers to: https://github.com/platform-mesh/kubernetes-graphql-gateway/issues/222