### PR TITLE
feat: expose active subscription count as Prometheus metrics

### DIFF
--- a/gateway/config.go
+++ b/gateway/config.go
@@ -5,8 +5,11 @@ import (
 
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway"
 	gatewayconfig "github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/config"
+	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/metrics"
+	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/gateway/middleware"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/http"
 	"github.com/platform-mesh/kubernetes-graphql-gateway/gateway/options"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type Config struct {
@@ -43,6 +46,8 @@ func NewConfig(opts *options.CompletedOptions) (*Config, error) {
 	}
 	cfg.Gateway = gatewayServer
 
+	subMetrics := metrics.NewSubscriptionMetrics(prometheus.DefaultRegisterer)
+
 	httpServer, err := http.NewServer(http.ServerConfig{
 		Gateway:                  gatewayServer,
 		ReadyzCheck:              gatewayServer.IsReady,
@@ -56,6 +61,11 @@ func NewConfig(opts *options.CompletedOptions) (*Config, error) {
 		ReadHeaderTimeout:        cfg.Options.ReadHeaderTimeout,
 		IdleTimeout:              cfg.Options.IdleTimeout,
 		EndpointSuffix:           cfg.Options.EndpointSuffix,
+		SubscriptionMetrics: &middleware.InFlightMetrics{
+			Active:   subMetrics.Active,
+			Total:    subMetrics.Total,
+			Rejected: subMetrics.Rejected,
+		},
 		CORSConfig: http.CORSConfig{
 			AllowedOrigins:   cfg.Options.CORSAllowedOrigins,
 			AllowedHeaders:   cfg.Options.CORSAllowedHeaders,

--- a/gateway/gateway/metrics/metrics.go
+++ b/gateway/gateway/metrics/metrics.go
@@ -1,0 +1,28 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type SubscriptionMetrics struct {
+	Active   prometheus.Gauge
+	Total    prometheus.Counter
+	Rejected prometheus.Counter
+}
+
+func NewSubscriptionMetrics(reg prometheus.Registerer) *SubscriptionMetrics {
+	m := &SubscriptionMetrics{
+		Active: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "graphql_subscriptions_active",
+			Help: "Current number of active (in-flight) GraphQL subscriptions.",
+		}),
+		Total: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "graphql_subscriptions_total",
+			Help: "Total number of GraphQL subscriptions opened.",
+		}),
+		Rejected: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "graphql_subscriptions_rejected_total",
+			Help: "Total number of GraphQL subscriptions rejected due to max-inflight limit.",
+		}),
+	}
+	reg.MustRegister(m.Active, m.Total, m.Rejected)
+	return m
+}

--- a/gateway/gateway/metrics/metrics_test.go
+++ b/gateway/gateway/metrics/metrics_test.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSubscriptionMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewSubscriptionMetrics(reg)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	names := make(map[string]struct{})
+	for _, f := range families {
+		names[f.GetName()] = struct{}{}
+	}
+	assert.Contains(t, names, "graphql_subscriptions_active")
+	assert.Contains(t, names, "graphql_subscriptions_total")
+	assert.Contains(t, names, "graphql_subscriptions_rejected_total")
+
+	assert.Equal(t, 0.0, gaugeValue(t, m.Active))
+	assert.Equal(t, 0.0, counterValue(t, m.Total))
+	assert.Equal(t, 0.0, counterValue(t, m.Rejected))
+}
+
+func TestSubscriptionMetricsIncDec(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewSubscriptionMetrics(reg)
+
+	m.Active.Inc()
+	m.Active.Inc()
+	m.Total.Inc()
+	m.Total.Inc()
+	m.Total.Inc()
+	m.Rejected.Inc()
+
+	assert.Equal(t, 2.0, gaugeValue(t, m.Active))
+	assert.Equal(t, 3.0, counterValue(t, m.Total))
+	assert.Equal(t, 1.0, counterValue(t, m.Rejected))
+
+	m.Active.Dec()
+	assert.Equal(t, 1.0, gaugeValue(t, m.Active))
+}
+
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, g.Write(&m))
+	return m.GetGauge().GetValue()
+}
+
+func counterValue(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, c.Write(&m))
+	return m.GetCounter().GetValue()
+}

--- a/gateway/gateway/middleware/maxinflight.go
+++ b/gateway/gateway/middleware/maxinflight.go
@@ -2,10 +2,22 @@ package middleware
 
 import "net/http"
 
+// InFlightMetrics provides optional instrumentation for the max-inflight middleware.
+// When non-nil, the middleware calls these methods on acquire, release, and reject.
+type InFlightMetrics struct {
+	Active interface {
+		Inc()
+		Dec()
+	}
+	Total    interface{ Inc() }
+	Rejected interface{ Inc() }
+}
+
 // WithMaxInFlightRequests returns a middleware that limits the number of concurrent
 // requests being processed. When the limit is reached, new requests receive a
 // 429 Too Many Requests response. Setting maxInFlight to 0 or less disables the limit.
-func WithMaxInFlightRequests(handler http.Handler, maxInFlight int) http.Handler {
+// When metrics is non-nil, the middleware tracks active, total, and rejected counts.
+func WithMaxInFlightRequests(handler http.Handler, maxInFlight int, metrics *InFlightMetrics) http.Handler {
 	if maxInFlight <= 0 {
 		return handler
 	}
@@ -13,9 +25,21 @@ func WithMaxInFlightRequests(handler http.Handler, maxInFlight int) http.Handler
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case sem <- struct{}{}:
-			defer func() { <-sem }()
+			if metrics != nil {
+				metrics.Active.Inc()
+				metrics.Total.Inc()
+			}
+			defer func() {
+				if metrics != nil {
+					metrics.Active.Dec()
+				}
+				<-sem
+			}()
 			handler.ServeHTTP(w, r)
 		default:
+			if metrics != nil {
+				metrics.Rejected.Inc()
+			}
 			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 		}
 	})

--- a/gateway/gateway/middleware/maxinflight_test.go
+++ b/gateway/gateway/middleware/maxinflight_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -134,7 +135,7 @@ func TestWithMaxInFlightRequests(t *testing.T) {
 			started := make(chan struct{}, 10)
 			release := make(chan struct{})
 
-			handler := WithMaxInFlightRequests(tt.handler(started, release), tt.maxInFlight)
+			handler := WithMaxInFlightRequests(tt.handler(started, release), tt.maxInFlight, nil)
 			server := httptest.NewServer(handler)
 			defer server.Close()
 
@@ -142,3 +143,91 @@ func TestWithMaxInFlightRequests(t *testing.T) {
 		})
 	}
 }
+
+func TestWithMaxInFlightRequestsMetrics(t *testing.T) {
+	t.Run("metrics incremented on successful request", func(t *testing.T) {
+		m := &fakeMetrics{}
+		metrics := &InFlightMetrics{
+			Active:   m,
+			Total:    &fakeCounter{&m.totalInc},
+			Rejected: &fakeCounter{&m.rejectedInc},
+		}
+
+		handler := WithMaxInFlightRequests(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Inside handler: active should be 1
+			assert.Equal(t, int64(1), m.active.Load())
+			w.WriteHeader(http.StatusOK)
+		}), 10, metrics)
+
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		resp, err := http.Get(server.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close() //nolint:errcheck
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, int64(0), m.active.Load())
+		assert.Equal(t, int64(1), m.totalInc.Load())
+		assert.Equal(t, int64(0), m.rejectedInc.Load())
+	})
+
+	t.Run("rejected metric incremented at capacity", func(t *testing.T) {
+		m := &fakeMetrics{}
+		metrics := &InFlightMetrics{
+			Active:   m,
+			Total:    &fakeCounter{&m.totalInc},
+			Rejected: &fakeCounter{&m.rejectedInc},
+		}
+
+		started := make(chan struct{})
+		release := make(chan struct{})
+
+		handler := WithMaxInFlightRequests(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			started <- struct{}{}
+			<-release
+			w.WriteHeader(http.StatusOK)
+		}), 1, metrics)
+
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		// Fill the single slot
+		go func() {
+			resp, _ := http.Get(server.URL) //nolint:errcheck
+			if resp != nil {
+				resp.Body.Close() //nolint:errcheck
+			}
+		}()
+		<-started
+
+		// This request should be rejected
+		resp, err := http.Get(server.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close() //nolint:errcheck
+
+		assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+		assert.Equal(t, int64(1), m.active.Load())
+		assert.Equal(t, int64(1), m.totalInc.Load())
+		assert.Equal(t, int64(1), m.rejectedInc.Load())
+
+		close(release)
+	})
+}
+
+// fakeMetrics implements the Active gauge interface (Inc/Dec) using atomics.
+type fakeMetrics struct {
+	active      atomic.Int64
+	totalInc    atomic.Int64
+	rejectedInc atomic.Int64
+}
+
+func (f *fakeMetrics) Inc() { f.active.Add(1) }
+func (f *fakeMetrics) Dec() { f.active.Add(-1) }
+
+// fakeCounter implements the counter interface (Inc) using an atomic.
+type fakeCounter struct {
+	val *atomic.Int64
+}
+
+func (f *fakeCounter) Inc() { f.val.Add(1) }

--- a/gateway/http/http.go
+++ b/gateway/http/http.go
@@ -37,6 +37,10 @@ type ServerConfig struct {
 	ReadHeaderTimeout        time.Duration
 	IdleTimeout              time.Duration
 
+	// SubscriptionMetrics provides optional Prometheus instrumentation for
+	// the subscription concurrency limiter. When nil, no metrics are recorded.
+	SubscriptionMetrics *middleware.InFlightMetrics
+
 	Addr           string
 	EndpointSuffix string
 }
@@ -56,8 +60,8 @@ type Server struct {
 func NewServer(c ServerConfig) (*Server, error) {
 	s := http.NewServeMux()
 
-	queryHandler := middleware.WithMaxInFlightRequests(middleware.WithTimeout(c.Gateway, c.RequestTimeout), c.MaxInFlightRequests)
-	subscriptionHandler := middleware.WithMaxInFlightRequests(middleware.WithTimeout(c.Gateway, c.SubscriptionTimeout), c.MaxInFlightSubscriptions)
+	queryHandler := middleware.WithMaxInFlightRequests(middleware.WithTimeout(c.Gateway, c.RequestTimeout), c.MaxInFlightRequests, nil)
+	subscriptionHandler := middleware.WithMaxInFlightRequests(middleware.WithTimeout(c.Gateway, c.SubscriptionTimeout), c.MaxInFlightSubscriptions, c.SubscriptionMetrics)
 
 	s.Handle(fmt.Sprintf("/api/clusters/{clusterName}%s", c.EndpointSuffix), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if c.MaxRequestBodyBytes > 0 {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/kcp-dev/multicluster-provider v0.5.1
 	github.com/kcp-dev/sdk v0.31.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/rs/cors v1.11.1
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
@@ -87,7 +88,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/gomega v1.38.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect


### PR DESCRIPTION
## Summary
- Adds `graphql_subscriptions_active` (gauge), `graphql_subscriptions_total` (counter), and `graphql_subscriptions_rejected_total` (counter) to the gateway's `/metrics` endpoint
- Extends `WithMaxInFlightRequests` with an optional `*InFlightMetrics` parameter (nil = no-op) — no separate middleware variant needed
- Metrics are decoupled from Prometheus via small interfaces and registered with an injectable `prometheus.Registerer`

Closes #233