### PR TITLE
fix(deps): upgrade multicluster-runtime to v0.23.3 and multicluster-provider to v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4
 	github.com/jellydator/ttlcache/v3 v3.4.0
-	github.com/kcp-dev/multicluster-provider v0.5.1
+	github.com/kcp-dev/multicluster-provider v0.6.0
 	github.com/kcp-dev/sdk v0.31.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/cors v1.11.1
@@ -39,7 +39,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/controller-runtime v0.23.3
-	sigs.k8s.io/multicluster-runtime v0.23.1
+	sigs.k8s.io/multicluster-runtime v0.23.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/kcp-dev/apimachinery/v2 v2.31.1 h1:CHAPoYy5JEMsby1WUId/JLs1QEPDz1lSwQ
 github.com/kcp-dev/apimachinery/v2 v2.31.1/go.mod h1:ta+d3xQkLYWBEEg8ICed+PekW3MckEYqXG4amq6Uk9Y=
 github.com/kcp-dev/logicalcluster/v3 v3.0.5 h1:JbYakokb+5Uinz09oTXomSUJVQsqfxEvU4RyHUYxHOU=
 github.com/kcp-dev/logicalcluster/v3 v3.0.5/go.mod h1:EWBUBxdr49fUB1cLMO4nOdBWmYifLbP1LfoL20KkXYY=
-github.com/kcp-dev/multicluster-provider v0.5.1 h1:2qMZzLPvzClT2ks+AMyE97PD+2lrDv3r0wDCKBxsr7E=
-github.com/kcp-dev/multicluster-provider v0.5.1/go.mod h1:eJohrSXqLmpjfTSFBbZMoq4Osr57UKg9ZokvhCPNmHc=
+github.com/kcp-dev/multicluster-provider v0.6.0 h1:t7Wac92T4dde9DMMVqA/VPhNhrqkgZ4/Cyij0yh0M5s=
+github.com/kcp-dev/multicluster-provider v0.6.0/go.mod h1:pJvWD+5dP+aMsntlu7sBG7oOmYrWfuWKqDQ8WBHur34=
 github.com/kcp-dev/sdk v0.31.1 h1:d6OJhRLoD0UKfHXWOEwflDk4SMh1C9PlhE2VcDONBvo=
 github.com/kcp-dev/sdk v0.31.1/go.mod h1:FeeJoxqqpDwvEqzuFKcp/IkSlj/KyZRKbiAud1IHUYU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -327,8 +327,8 @@ sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4i
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/multicluster-runtime v0.23.1 h1:isjVh6zBuk/U1HjYm22knRZmFsn6sFinmyvV+/4puCc=
-sigs.k8s.io/multicluster-runtime v0.23.1/go.mod h1:ri1Gvx7Qehy5nis6OnTgSpJIWaf2SuorHDwF/jvbWvM=
+sigs.k8s.io/multicluster-runtime v0.23.3 h1:vrzlXRzHTDsjspUAfoW2rCtr0agoI4q20p9x4Fz4png=
+sigs.k8s.io/multicluster-runtime v0.23.3/go.mod h1:r/UA4GHgFoXCcR4tcvlZz7SiLx3l1kJKDuBAhILNIHs=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 h1:2WOzJpHUBVrrkDjU4KBT8n5LDcj824eX0I5UKcgeRUs=

--- a/listener/config.go
+++ b/listener/config.go
@@ -309,8 +309,8 @@ func buildControllerForOptions(names string, defaultNames string) []mcbuilder.Fo
 	}
 
 	return []mcbuilder.ForOption{
-		mcbuilder.WithClusterFilter(func(clusterName string, _ ctrlcluster.Cluster) bool {
-			prefix, _, ok := strings.Cut(clusterName, "#")
+		mcbuilder.WithClusterFilter(func(clusterName multicluster.ClusterName, _ ctrlcluster.Cluster) bool {
+			prefix, _, ok := strings.Cut(string(clusterName), "#")
 			if !ok {
 				return false
 			}

--- a/listener/controllers/reconciler/cluster_name.go
+++ b/listener/controllers/reconciler/cluster_name.go
@@ -1,13 +1,17 @@
 package reconciler
 
-import "strings"
+import (
+	"strings"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+)
 
 // ClusterName strips the multi-provider prefix from a cluster name.
 // The multi.Provider from multicluster-runtime prefixes cluster names as
 // "providerName#clusterName". This function returns the original cluster name.
-func ClusterName(name string) string {
-	if _, after, ok := strings.Cut(name, "#"); ok {
+func ClusterName(name multicluster.ClusterName) string {
+	if _, after, ok := strings.Cut(string(name), "#"); ok {
 		return after
 	}
-	return name
+	return string(name)
 }

--- a/providers/kcp/provider.go
+++ b/providers/kcp/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
@@ -37,16 +36,6 @@ func New(cfg *rest.Config, endpointSliceName string, options provider.Options) (
 	}, nil
 }
 
-// Get returns the cluster with the given name as a cluster.Cluster.
-func (p *Provider) Get(ctx context.Context, clusterName string) (cluster.Cluster, error) {
-	return p.Provider.Get(ctx, clusterName)
-}
-
-// IndexField adds an indexer to the clusters managed by this provider.
-func (p *Provider) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
-	return p.Provider.IndexField(ctx, obj, field, extractValue)
-}
-
 // Start starts the provider and blocks.
 func (p *Provider) Start(ctx context.Context, aware multicluster.Aware) error {
 	return p.Provider.Start(ctx, &awareWrapper{Aware: aware})
@@ -58,7 +47,6 @@ type awareWrapper struct {
 	multicluster.Aware
 }
 
-func (a *awareWrapper) Engage(ctx context.Context, name string, cluster cluster.Cluster) error {
+func (a *awareWrapper) Engage(ctx context.Context, name multicluster.ClusterName, cluster cluster.Cluster) error {
 	return a.Aware.Engage(ctx, name, cluster)
-
 }


### PR DESCRIPTION
## Summary
- Upgrades `sigs.k8s.io/multicluster-runtime` from v0.23.1 to v0.23.3
- Upgrades `github.com/kcp-dev/multicluster-provider` from v0.5.1 to v0.6.0
- Adapts code to the new `multicluster.ClusterName` type (previously plain `string`)

These two upgrades are interdependent — multicluster-runtime v0.23.3 introduced a dedicated `ClusterName` type, and multicluster-provider v0.6.0 was built against it. This is why PR #194 and PR #213 were both stuck failing CI individually.

## Changes
- `providers/kcp/provider.go`: Removed redundant `Get`/`IndexField` pass-through methods (promoted from embedded type), updated `Engage` signature to use `multicluster.ClusterName`
- `listener/controllers/reconciler/cluster_name.go`: Updated `ClusterName()` to accept `multicluster.ClusterName` instead of `string`
- `listener/config.go`: Updated cluster filter function signature to use `multicluster.ClusterName`

## Test plan
- [x] `task test` passes
- [x] `task lint` passes (0 issues)
- [x] `go build ./...` succeeds

Supersedes #194 and #213.