### PR TITLE
fix: route tokenreviews through target kcp workspace

### DIFF
--- a/apis/v1alpha1/clustermetadata_types.go
+++ b/apis/v1alpha1/clustermetadata_types.go
@@ -43,6 +43,7 @@ type ClusterMetadata struct {
 	Path                string        `json:"path,omitempty"`
 	RequestPathTemplate string        `json:"requestPathTemplate,omitempty"`
 	IntrospectionPath   string        `json:"introspectionPath,omitempty"`
+	TokenReviewHost     string        `json:"tokenReviewHost,omitempty"`
 	Auth                *AuthMetadata `json:"auth,omitempty"`
 	CA                  *CAMetadata   `json:"ca,omitempty"`
 }

--- a/gateway/gateway/cluster/cluster.go
+++ b/gateway/gateway/cluster/cluster.go
@@ -19,10 +19,11 @@ import (
 )
 
 type Cluster struct {
-	name     string
-	client   client.WithWatch
-	restCfg  *rest.Config
-	adminCfg *rest.Config
+	name           string
+	client         client.WithWatch
+	restCfg        *rest.Config
+	adminCfg       *rest.Config
+	tokenReviewCfg *rest.Config
 }
 
 // New creates a new Cluster connection from cluster metadata.
@@ -46,6 +47,13 @@ func New(
 	}
 
 	cluster.adminCfg = rest.CopyConfig(cluster.restCfg)
+	cluster.tokenReviewCfg = rest.CopyConfig(cluster.restCfg)
+	// When TokenReviewHost is set, all TokenReviews go to that fixed host (typically
+	// the gateway home workspace). Leave it empty so the request path template can
+	// target /clusters/<clusterName> and TokenReview runs in the workspace being queried.
+	if metadata.TokenReviewHost != "" {
+		cluster.tokenReviewCfg.Host = metadata.TokenReviewHost
+	}
 
 	basePath := hostPath(metadata.Host)
 	tpl := metadata.RequestPathTemplate
@@ -53,6 +61,11 @@ func New(
 	cluster.adminCfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
 		return roundtripper.NewPathTemplateHandler(rt, tpl, basePath)
 	})
+	if metadata.TokenReviewHost == "" {
+		cluster.tokenReviewCfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+			return roundtripper.NewPathTemplateHandler(rt, tpl, basePath)
+		})
+	}
 
 	tlsConfig := cluster.restCfg.TLSClientConfig
 	baseRT, err := roundtripper.NewBaseRoundTripper(tlsConfig)
@@ -97,16 +110,17 @@ func (c *Cluster) RestConfig() *rest.Config {
 	return rest.CopyConfig(c.restCfg)
 }
 
-// AdminConfig returns a rest.Config with the cluster's admin credentials,
-// suitable for privileged API calls like TokenReview.
-func (c *Cluster) AdminConfig() *rest.Config {
-	return rest.CopyConfig(c.adminCfg)
+// TokenReviewConfig returns a rest.Config configured for validating bearer
+// tokens against the workspace targeted by this cluster.
+func (c *Cluster) TokenReviewConfig() *rest.Config {
+	return rest.CopyConfig(c.tokenReviewCfg)
 }
 
 func (c *Cluster) Close() {
 	c.client = nil
 	c.adminCfg = nil
 	c.restCfg = nil
+	c.tokenReviewCfg = nil
 }
 
 func hostPath(host string) string {

--- a/gateway/gateway/endpoint/endpoint.go
+++ b/gateway/gateway/endpoint/endpoint.go
@@ -56,7 +56,7 @@ func New(
 	validatorCancel := context.CancelFunc(func() {})
 	if validator == nil {
 		validatorCtx, trCancel := context.WithCancel(ctx)
-		tr, err := authn.NewTokenReviewValidator(cl.AdminConfig(), tokenReviewCacheTTL)
+		tr, err := authn.NewTokenReviewValidator(cl.TokenReviewConfig(), tokenReviewCacheTTL)
 		if err != nil {
 			trCancel()
 			return nil, fmt.Errorf("failed to create token validator: %w", err)

--- a/providers/kcp/options/options.go
+++ b/providers/kcp/options/options.go
@@ -124,6 +124,8 @@ func (options *CompletedOptions) GetClusterMetadataOverrideFunc() v1alpha1.Clust
 			}
 			parsed.Path = path.Join("clusters", clusterName)
 			metadata.Host = parsed.String()
+			// Do not set metadata.TokenReviewHost: TokenReview must hit the same
+			// per-cluster path as GraphQL (see gateway/gateway/cluster/cluster.go).
 
 			return metadata, nil
 		}

--- a/providers/kcp/options/options_test.go
+++ b/providers/kcp/options/options_test.go
@@ -3,6 +3,8 @@ package options
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
 )
 
@@ -70,4 +72,23 @@ func TestApplyLogicalClusterToConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetClusterMetadataOverrideFunc_perClusterHostWithoutTokenReviewHost(t *testing.T) {
+	opts, err := (&Options{
+		ExtraOptions: ExtraOptions{
+			WorkspaceSchemaKubeconfigRestConfig: &rest.Config{
+				Host: "https://kcp.example/clusters/root:platform-mesh-system",
+			},
+		},
+	}).Complete()
+	require.NoError(t, err)
+
+	override := opts.GetClusterMetadataOverrideFunc()
+	metadata, err := override("root:orgs:org1:account1")
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+
+	assert.Equal(t, "https://kcp.example/clusters/root:orgs:org1:account1", metadata.Host)
+	assert.Empty(t, metadata.TokenReviewHost, "TokenReview must use per-cluster path injection, not a fixed home workspace host")
 }


### PR DESCRIPTION
## Summary
This fixes TokenReview routing for KCP-backed GraphQL endpoints when the gateway runs with a scoped provider kubeconfig.
Previously, TokenReview requests were sent to the gateway home workspace because `TokenReviewHost` was static. The gateway now leaves `TokenReviewHost` empty so TokenReview uses the per-cluster request path and runs in the queried workspace.
## Test Plan
- Added/updated unit coverage for KCP cluster metadata.
- Verified GraphQL requests against account workspaces no longer fail with 503 when paired with the security-operator 